### PR TITLE
low-level EXI codec: add helper functions

### DIFF
--- a/src/input/code_templates/c/static_code/exi_bitstream_c.ctc
+++ b/src/input/code_templates/c/static_code/exi_bitstream_c.ctc
@@ -112,6 +112,42 @@ void exi_bitstream_init(exi_bitstream_t* stream, uint8_t* data, size_t data_size
 {%- endif %}
 }
 
+void exi_bitstream_reset(exi_bitstream_t* stream)
+{
+    if (stream->_init_called)
+    {
+        stream->byte_pos = stream->_flag_byte_pos;
+    }
+    else
+    {
+        stream->byte_pos = 0;
+    }
+
+    stream->bit_count = 0;
+
+{%- if add_debug_code == 1 %}
+
+    if (stream->status_callback)
+    {
+        stream->status_callback(EXI_DEBUG__BITSTREAM_RESET, 0, stream->byte_pos, 0);
+    }
+{%- endif %}
+}
+
+size_t exi_bitstream_get_length(exi_bitstream_t* stream)
+{
+    size_t length = stream->byte_pos;
+
+    if (stream->_init_called && (stream->_flag_byte_pos > 0))
+    {
+        length -= stream->_flag_byte_pos;
+    }
+
+    length += stream->bit_count > 0u ? 1u : 0u;
+
+    return length;
+}
+
 int exi_bitstream_write_bits(exi_bitstream_t* stream, size_t bit_count, uint32_t value)
 {
 {%- if add_debug_code == 1 %}

--- a/src/input/code_templates/c/static_code/exi_bitstream_h.ctc
+++ b/src/input/code_templates/c/static_code/exi_bitstream_h.ctc
@@ -11,9 +11,10 @@
  * internal IDs for callback
  *****************************************************************************/
 #define EXI_DEBUG__BITSTREAM_INIT -1
-#define EXI_DEBUG__BITSTREAM_BYTE_POS_CHANGED -2
-#define EXI_DEBUG__BITSTREAM_WRITE_BIT -3
-#define EXI_DEBUG__BITSTREAM_READ_BIT -4
+#define EXI_DEBUG__BITSTREAM_RESET -2
+#define EXI_DEBUG__BITSTREAM_BYTE_POS_CHANGED -3
+#define EXI_DEBUG__BITSTREAM_WRITE_BIT -4
+#define EXI_DEBUG__BITSTREAM_READ_BIT -5
 
 #define EXI_DEBUG__BITSTREAM_WRITE_BITS -10
 #define EXI_DEBUG__BITSTREAM_READ_BITS -11
@@ -60,6 +61,10 @@ typedef struct {
     uint8_t bit_count;
     size_t byte_pos;
 
+    /* flags for reset and length function */
+    uint8_t _init_called;
+    size_t _flag_byte_pos;
+
     /* Pointer to callback for reporting errors or logging if assigned */
     exi_status_callback status_callback;
 } exi_bitstream_t;
@@ -78,6 +83,27 @@ typedef struct {
  *
  */
 void exi_bitstream_init(exi_bitstream_t* stream, uint8_t* data, size_t data_size, size_t data_offset, exi_status_callback status_callback);
+
+/**
+ * \brief       bitstream reset
+ *
+ *              Resets the exi bitstream to the parameters from the last init state.
+ *
+ * \param       stream      input or output stream
+ *
+ */
+void exi_bitstream_reset(exi_bitstream_t* stream);
+
+/**
+ * \brief       bitstream get length
+ *
+ *              Returns the length of the stream.
+ *
+ * \param       stream      output Stream
+ * \return                  length of stream
+ *
+ */
+size_t exi_bitstream_get_length(exi_bitstream_t* stream);
 
 /**
  * \brief       bitstream write bits

--- a/src/input/code_templates/c/static_code/exi_debug_log_c.ctc
+++ b/src/input/code_templates/c/static_code/exi_debug_log_c.ctc
@@ -25,6 +25,10 @@ static void status_internal(int message_id, int status_code, int value_1, int va
         fprintf(logfile, "\n********************************************************************************\n");
         fprintf(logfile, "exi_bitstream_t - init: byte_pos = %d\n", value_1);
         break;
+    case EXI_DEBUG__BITSTREAM_RESET:
+        fprintf(logfile, "\n********************************************************************************\n");
+        fprintf(logfile, "exi_bitstream_t - reset: byte_pos = %d\n", value_1);
+        break;
     case EXI_DEBUG__BITSTREAM_BYTE_POS_CHANGED:
         fprintf(logfile, "exi_bitstream_t - byte_pos changed: byte_pos = %d\n", value_1);
         break;


### PR DESCRIPTION
These functions assist in:
- calculating the correct encoding length
- re-using the same stream variable