### PR TITLE
fix grammars for choices, and for abstracts and their realizations

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -44,7 +44,7 @@ iso2_array_optimizations = {
     'PMaxScheduleEntryType': 12,
     'SalesTariffEntryType': 12,
     'ParameterSetType': 5,
-    'X509IssuerSerialType': 5
+    'X509IssuerSerialType': 5  # this shall apply to array ListOfRootCertificateIDsType->RootCertificateID only
 }
 
 # general c-code style

--- a/src/input/code_templates/c/BaseInitWithArrayLenAndUsed.ctc
+++ b/src/input/code_templates/c/BaseInitWithArrayLenAndUsed.ctc
@@ -9,4 +9,4 @@ void {{ function_name }}(struct {{ struct_type }}* {{ parameter_name }}) {
     {%- for name in elements %}
     {{ parameter_name }}->{{ name }}_isUsed = 0u;
     {%- endfor %}
-};
+}

--- a/src/input/code_templates/c/BaseInitWithUsed.ctc
+++ b/src/input/code_templates/c/BaseInitWithUsed.ctc
@@ -6,4 +6,4 @@ void {{ function_name }}(struct {{ struct_type }}* {{ parameter_name }}) {
     {%- for name in elements %}
     {{ parameter_name }}->{{ name }}_isUsed = 0u;
     {%- endfor %}
-};
+}

--- a/src/input/code_templates/c/encoder/EncodeEventOptionalElementNone.ctc
+++ b/src/input/code_templates/c/encoder/EncodeEventOptionalElementNone.ctc
@@ -1,0 +1,11 @@
+{%- if option == 0 %}
+{{ indent * level }}if (1 == 0)
+{%- elif option > 0 %}
+{{ indent * level }}else if (1 == 0)
+{%- else %}
+{{ indent * level }}else
+{%- endif %}
+{{ indent * level }}{
+{{ indent * (level + 1) }}{{ event_comment }}
+{{ type_content }}
+{{ indent * level }}}

--- a/src/v2g_exi_codec_gen/SchemaAnalyzer.py
+++ b/src/v2g_exi_codec_gen/SchemaAnalyzer.py
@@ -1260,6 +1260,8 @@ class SchemaAnalyzer(object):
                         particle.content_model_changed_restrictions = True
                         particle.min_occurs_old = particle.min_occurs
                         particle.min_occurs = 0
+                        # we may need to force this to avoid peculiar choice particle properties
+                        # particle.max_occurs = 1
 
     def __apply_array_optimizations(self):
         config_module = get_config_module()
@@ -1271,7 +1273,8 @@ class SchemaAnalyzer(object):
 
         for element in self.__generate_elements:
             for particle in element.particles:
-                if particle.type_short in optimizations.keys():
+                if (particle.type_short in optimizations.keys()
+                    and particle.max_occurs > optimizations[particle.type_short]):
                     particle.max_occurs = optimizations[particle.type_short]
 
     def __prepare_for_type_generation(self):

--- a/src/v2g_exi_codec_gen/base_coder_classes.py
+++ b/src/v2g_exi_codec_gen/base_coder_classes.py
@@ -375,9 +375,9 @@ class ExiBaseCoderCode:
         grammar = self.create_empty_grammar()
 
         def _add_subsequent_grammar_details(element: ElementData, particle: Particle,
-                                            grammar: ElementGrammar,
                                             particle_index: int, index_last_nonoptional_particle: int,
                                             particle_is_part_of_sequence: bool):
+            nonlocal grammar
             if particle_index > index_last_nonoptional_particle:
                 # all the following particles are optional, so END needs to be an expected event
                 # at the beginning of the event/grammar detail list
@@ -449,7 +449,7 @@ class ExiBaseCoderCode:
                                 _max += 1
                         for m in range(0, _max):
                             if m >= part.min_occurs and m > 0:  # optional, and grammar 0 already contains END
-                                _add_subsequent_grammar_details(element, particle, grammar, n + 1,
+                                _add_subsequent_grammar_details(element, particle, n + 1,
                                                                 index_last_nonoptional_particle,
                                                                 particle_is_part_of_sequence)
 
@@ -490,7 +490,7 @@ class ExiBaseCoderCode:
                 if choice_list:
                     previous_choice_list.extend(choice_list[1])
 
-            _add_subsequent_grammar_details(element, particle, grammar, particle_index,
+            _add_subsequent_grammar_details(element, particle, particle_index,
                                             index_last_nonoptional_particle, particle_is_part_of_sequence)
             grammar = self.create_empty_grammar()
 

--- a/src/v2g_exi_codec_gen/base_coder_classes.py
+++ b/src/v2g_exi_codec_gen/base_coder_classes.py
@@ -377,6 +377,8 @@ class ExiBaseCoderCode:
         def _add_subsequent_grammar_details(element: ElementData, particle: Particle,
                                             particle_index: int, index_last_nonoptional_particle: int,
                                             particle_is_part_of_sequence: bool):
+            # we push the grammar to a list below, and assign a new object to this variable;
+            # this assignment does not apply globally if the grammar is passed in
             nonlocal grammar
             if particle_index > index_last_nonoptional_particle:
                 # all the following particles are optional, so END needs to be an expected event

--- a/src/v2g_exi_codec_gen/datatype_classes.py
+++ b/src/v2g_exi_codec_gen/datatype_classes.py
@@ -478,6 +478,9 @@ class DatatypeHeader:
             else:
                 define_list = self.__get_define_list(element)
                 struct_content = self.__get_struct_content(element)
+                # avoid empty structs
+                if struct_content == '':
+                    struct_content += '    int _unused;'
 
                 temp = self.generator.get_template('BaseStructWithDefine.ctc')
                 content += temp.render(defines=define_list,

--- a/src/v2g_exi_codec_gen/decoder_classes.py
+++ b/src/v2g_exi_codec_gen/decoder_classes.py
@@ -450,6 +450,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
                                     f'{detail.particle.type_short} ({detail.particle.typename})); ' + \
                                     f'next={detail.next_grammar}'
                 else:
+                    # unsupported particle which appears in the event list
                     event_comment = f'// Event: {detail.flag} (None); next={detail.next_grammar}'
                 # currently not used, should be removed if it seems not to be useful!
                 # add_debug_code = self.get_status_for_add_debug_code(grammar.element_typename)

--- a/src/v2g_exi_codec_gen/decoder_classes.py
+++ b/src/v2g_exi_codec_gen/decoder_classes.py
@@ -445,10 +445,12 @@ class ExiDecoderCode(ExiBaseCoderCode):
                     end_id = index
                     continue
 
-                event_comment = f'// Event: {detail.flag} ({detail.particle.name}, ' + \
-                                f'{detail.particle.type_short} ({detail.particle.typename})); ' + \
-                                f'next={detail.next_grammar}'
-                event_comment = f'// Event: {detail.flag} ({detail.particle.name}, {detail.particle.type_short} ({detail.particle.typename})); next={detail.next_grammar}'
+                if detail.particle is not None:
+                    event_comment = f'// Event: {detail.flag} ({detail.particle.name}, ' + \
+                                    f'{detail.particle.type_short} ({detail.particle.typename})); ' + \
+                                    f'next={detail.next_grammar}'
+                else:
+                    event_comment = f'// Event: {detail.flag} (None); next={detail.next_grammar}'
                 # currently not used, should be removed if it seems not to be useful!
                 # add_debug_code = self.get_status_for_add_debug_code(grammar.element_typename)
                 # type_parameter = CONFIG_PARAMS['decode_function_prefix'] + grammar.element_typename
@@ -533,7 +535,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
                 add_debug_code = 0
                 type_parameter = ''
                 for detail in grammar.details:
-                    if detail.flag == GrammarFlag.START:
+                    if detail.flag == GrammarFlag.START and detail.particle is not None:
                         prefixed_type = detail.particle.prefixed_name
                         add_debug_code = self.get_status_for_add_debug_code(prefixed_type)
                         type_parameter = CONFIG_PARAMS['decode_function_prefix'] + prefixed_type

--- a/src/v2g_exi_codec_gen/elementData.py
+++ b/src/v2g_exi_codec_gen/elementData.py
@@ -334,35 +334,46 @@ class ElementData:
 
     @property
     def element_comment(self):
+        comment_parts = []
+        comment_parts.append("definition=" + self.type_definition)
+        comment_parts.append("name=" + self.name)
+        comment_parts.append("type=" + self.type)
+        comment_parts.append("base type=" + self.base_type)
+        comment_parts.append("content type=" + self.content_type)
         comment = "// Element: "
-        comment += "definition=" + self.type_definition + "; "
-        comment += "name=" + self.name + "; "
-        comment += "type=" + self.type + "; "
-        comment += "base type=" + self.base_type + "; "
-        comment += "content type=" + self.content_type + ";\n"
-        comment += "//          "
-        comment += "abstract=" + str(self.abstract) + "; "
-        comment += "final=" + str(self.final) + "; "
+        comment += '; '.join(comment_parts) + ';\n'
+
+        comment_parts.clear()
+        comment_parts.append("abstract=" + str(self.abstract))
+        comment_parts.append("final=" + str(self.final))
         if self.derivation:
-            comment += "derivation=" + self.derivation + "; "
+            comment_parts.append("derivation=" + self.derivation)
         if self.is_choice:
-            comment += "choice=" + str(self.is_choice) + "; "
+            comment_parts.append("choice=" + str(self.is_choice))
         if self.has_sequence:
-            comment += "sequence=" + str(self.has_sequence) + " (" + str(len(self.sequences)) + "); "
+            comment_parts.append("sequence=" + str(self.has_sequence) + " (" + str(len(self.sequences)))
+        comment += "//          "
+        comment += '; '.join(comment_parts)
+        if comment_parts:
+            comment += ';'
 
         return comment
 
     @property
     def particle_comment(self):
-        comment = '// Particle: '
+        comment_parts = []
         for particle in self.particles:
-            comment += f'{particle.name}, {particle.type_short} ('
-            comment += f'{particle.min_occurs}, {particle.max_occurs})'
+            comment_part = f'{particle.name}, {particle.type_short} ('
+            comment_part += f'{particle.min_occurs}, {particle.max_occurs})'
 
             if particle.parent_has_sequence:
-                comment += f'(was {particle.min_occurs_old}, {particle.max_occurs_old})'
-                comment += f'(seq. {particle.parent_sequence})'
+                comment_part += f'(was {particle.min_occurs_old}, {particle.max_occurs_old})'
+                comment_part += f'(seq. {particle.parent_sequence})'
 
-            comment += '; '
+            comment_parts.append(comment_part)
 
+        comment = '// Particle: '
+        comment += '; '.join(comment_parts)
+        if comment_parts:
+            comment += ';'
         return comment

--- a/src/v2g_exi_codec_gen/elementData.py
+++ b/src/v2g_exi_codec_gen/elementData.py
@@ -243,6 +243,7 @@ class Choice:
         self.multi_choice_max: int = 0
         self.choice_items = []
         self.choice_sequences = []
+        self.min_occurs = -1
 
     @property
     def choice_item_count(self) -> int:
@@ -283,7 +284,7 @@ class ElementData:
     has_abstract_particle: bool = False
     # additional info if element contains abstract particles and realizations
     has_abstract_sequence: bool = False
-    abstract_sequences = []
+    abstract_sequences = []  # list of tuples (list of particles, min_occurs, max_occurs)
     # list of particles
     particles = []
     # additional info if content model is choice

--- a/src/v2g_exi_codec_gen/elementData.py
+++ b/src/v2g_exi_codec_gen/elementData.py
@@ -29,6 +29,8 @@ class Particle:
     is_attribute: bool = False
     is_simple_content: bool = False
     enum_count: int = -1
+    # additional flag if content model is choice and changed min occurrence
+    content_model_changed_restrictions: bool = False
     # additional flag if parent content model is sequence and changed occurrence
     parent_model_changed_restrictions: bool = False
     parent_has_sequence: bool = False

--- a/src/v2g_exi_codec_gen/elementData.py
+++ b/src/v2g_exi_codec_gen/elementData.py
@@ -378,3 +378,9 @@ class ElementData:
         if comment_parts:
             comment += ';'
         return comment
+
+    def particle_from_name(self, particle_name: str) -> Particle:
+        for particle in self.particles:
+            if particle.name == particle_name:
+                return particle
+        return None

--- a/src/v2g_exi_codec_gen/encoder_classes.py
+++ b/src/v2g_exi_codec_gen/encoder_classes.py
@@ -408,25 +408,35 @@ class ExiEncoderCode(ExiBaseCoderCode):
         if detail.flag == GrammarFlag.END:
             content += self.__get_event_content_for_end_element(detail, grammar.bits_to_write, False, level)
         else:
-            event_comment = f'// Event: {detail.flag} ({detail.particle.name}, {detail.particle.typename})' \
-                            f'; next={detail.next_grammar}'
-            type_parameter = CONFIG_PARAMS['encode_function_prefix'] + detail.particle.prefixed_name
-            if detail.particle.parent_has_choice_sequence:
-                parameter = f'{grammar.element_typename}->choice_{detail.particle.parent_choice_sequence_number}.' \
-                            f'{detail.particle.name}'
-            else:
-                parameter = grammar.element_typename + '->' + detail.particle.name
+            if detail.particle is not None:
+                event_comment = f'// Event: {detail.flag} ({detail.particle.name}, {detail.particle.typename})' \
+                                f'; next={detail.next_grammar}'
+                type_parameter = CONFIG_PARAMS['encode_function_prefix'] + detail.particle.prefixed_name
+                if detail.particle.parent_has_choice_sequence:
+                    parameter = f'{grammar.element_typename}->choice_{detail.particle.parent_choice_sequence_number}.' \
+                                f'{detail.particle.name}'
+                else:
+                    parameter = grammar.element_typename + '->' + detail.particle.name
 
-            temp = self.generator.get_template('EncodeEventOptionalElement.ctc')
-            content += temp.render(option=option,
-                                   parameter=parameter,
-                                   bits_to_write=grammar.bits_to_write,
-                                   value_to_write=detail.event_index,
-                                   event_comment=event_comment,
-                                   type_content=self.__get_type_content(grammar, detail, 5),
-                                   add_debug_code=self.get_status_for_add_debug_code(detail.particle.prefixed_name),
-                                   type_parameter=type_parameter,
-                                   indent=self.indent, level=level)
+                temp = self.generator.get_template('EncodeEventOptionalElement.ctc')
+                content += temp.render(option=option,
+                                       parameter=parameter,
+                                       bits_to_write=grammar.bits_to_write,
+                                       value_to_write=detail.event_index,
+                                       event_comment=event_comment,
+                                       type_content=self.__get_type_content(grammar, detail, 5),
+                                       add_debug_code=self.get_status_for_add_debug_code(detail.particle.prefixed_name),
+                                       type_parameter=type_parameter,
+                                       indent=self.indent, level=level)
+            else:
+                event_comment = f'// Event: None (index={detail.event_index}); next={detail.next_grammar}'
+                type_content = str(self.indent * 4) + 'done = 1;'
+
+                temp = self.generator.get_template('EncodeEventOptionalElementNone.ctc')
+                content += temp.render(option=option,
+                                       event_comment=event_comment,
+                                       type_content=type_content,
+                                       indent=self.indent, level=level)
 
         content += '\n'
 

--- a/src/v2g_exi_codec_gen/encoder_classes.py
+++ b/src/v2g_exi_codec_gen/encoder_classes.py
@@ -429,6 +429,7 @@ class ExiEncoderCode(ExiBaseCoderCode):
                                        type_parameter=type_parameter,
                                        indent=self.indent, level=level)
             else:
+                # unsupported particle which appears in the event list
                 event_comment = f'// Event: None (index={detail.event_index}); next={detail.next_grammar}'
                 type_content = str(self.indent * 4) + 'done = 1;'
 

--- a/src/v2g_exi_codec_gen/typeDefinitions.py
+++ b/src/v2g_exi_codec_gen/typeDefinitions.py
@@ -53,4 +53,5 @@ OCCURRENCE_LIMITS_CORRECTED: Dict[str, int] = {
     "PaymentOption": 2,  # DIN schema uses unbounded, but restricts it to 2 [V2G-DC-634]
     "ProfileEntry": 24,  # DIN schema uses unbounded, but restricts it to 24 [V2G-DC-307]
     "SelectedService": 16,  # DIN schema uses unbounded, but restricts it to 1 [V2G-DC-635], ISO-2 uses 16
+    "SAScheduleTuple": 5,  # DIN schema uses unbounded, but restricts it to 5
 }


### PR DESCRIPTION
Now, all DIN 70121 and ISO 15118-2 EIM (AC and DC) messages can be encoded and decoded correctly, as far as tested with chargebyte's sample messages.

This changes the following:
* C source constructs conflicting with C99 - notably empty structs - were fixed. This fix in C is correct, but the implementation in Python may be considered a hack.

* Abstract particles which are expanded to their realizations are now correctly ordered within the event codes.

* Sequences which purely consist of choices are now correctly identified.

* Particles within a choice group are now correctly marked internally with min_occurs = 0, so that the corresponding _isUsed flags are generated and utilized.

* The actual min and max occurrences of the choices (not the internal marking of each choice particle) are now evaluated correctly.

* Particles which are not supported are now correctly represented with event codes and empty code blocks.

* The grammar and event code generation now correctly considers choices, as well as abstract particles represented with a choice of realizations.

* The occurrence limit for SAScheduleTuple was corrected. This fixes decoding of ChargeParameterDiscoveryRes.

* A workaround was set in place to avoid changing the max occurrence of X509IssuerSerial in X509Data. The modification probably needs to be avoided in a different manner.

* Occurrence limits artifically reduced to 1 now create a correct follow-up grammar, which needs to hold event codes for (truncated) repetitions. These codes were previously omitted, resulting in coding errors.

Known issues:
* Coding of anyURI attributes seems to be incorrect. This breaks PnC messages.

* Choices of sequences may still have incorrect grammars. This affects PGPDataType, which is only relevant for PnC.