### PR TITLE
Improve C code by better use of templates

### DIFF
--- a/src/cbexigen/decoder_classes.py
+++ b/src/cbexigen/decoder_classes.py
@@ -612,12 +612,13 @@ class ExiDecoderCode(ExiBaseCoderCode):
                                    indent=self.indent, level=1)
             content += '\n\n'
         else:
-            content += element.element_comment + '\n'
-            content += element.particle_comment + '\n'
-            content += self.get_function_declaration(typename, False) + '\n{\n'
-            content += self.indent + '// Element has no particles, so the function just returns zero\n'
-            content += self.indent + 'return 0;\n'
-            content += '}\n\n'
+            temp = self.generator.get_template('BaseEmptyFunction.jinja')
+            content += temp.render(element_comment=element.element_comment,
+                                   function_name=CONFIG_PARAMS['decode_function_prefix'] + element.prefixed_type,
+                                   struct_type=element.prefixed_type, parameter_name=typename,
+                                   add_debug_code=self.get_status_for_add_debug_code(element.prefixed_type),
+                                   indent=self.indent, level=1)
+            content += '\n\n'
 
         return content
 

--- a/src/cbexigen/encoder_classes.py
+++ b/src/cbexigen/encoder_classes.py
@@ -606,12 +606,13 @@ class ExiEncoderCode(ExiBaseCoderCode):
                                    indent=self.indent, level=1)
             content += '\n\n'
         else:
-            content += element.element_comment + '\n'
-            content += element.particle_comment + '\n'
-            content += self.get_function_declaration(typename, False) + '\n{\n'
-            content += self.indent + '// Element has no particles, so the function just returns zero\n'
-            content += self.indent + 'return 0;\n'
-            content += '}\n\n'
+            temp = self.generator.get_template('BaseEmptyFunction.jinja')
+            content += temp.render(element_comment=element.element_comment,
+                                   function_name=CONFIG_PARAMS['encode_function_prefix'] + element.prefixed_type,
+                                   struct_type=element.prefixed_type, parameter_name=typename,
+                                   add_debug_code=self.get_status_for_add_debug_code(element.prefixed_type),
+                                   indent=self.indent, level=1)
+            content += '\n\n'
 
         return content
 

--- a/src/input/code_templates/c/BaseEmptyFunction.jinja
+++ b/src/input/code_templates/c/BaseEmptyFunction.jinja
@@ -1,0 +1,16 @@
+{{ element_comment }}
+static int {{ function_name }}(exi_bitstream_t* stream, struct {{ struct_type }}* {{ parameter_name }}) {
+{{ indent * level }}// Element has no particles, so the function just returns zero
+{{ indent * level }}(void)stream;
+{{ indent * level }}(void){{ parameter_name }};
+
+{%- if add_debug_code == 1 %}
+
+{{ indent * level }}if (stream->status_callback)
+{{ indent * level }}{
+{{ indent * (level + 1) }}stream->status_callback({{ function_name|upper }}, 0, 0, 0);
+{{ indent * level }}}
+{%- endif %}
+
+{{ indent * level }}return 0;
+}

--- a/src/input/code_templates/c/static_code/exi_types_decoder.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_types_decoder.c.jinja
@@ -56,93 +56,82 @@ int decode_exi_type_hex_binary(exi_bitstream_t* stream, uint16_t* value_len, uin
 // *********
 // integers
 // *********
-#ifndef BUILD_DECODE_EXI_TYPE_INTEGER_N
-#define BUILD_DECODE_EXI_TYPE_INTEGER_N(bitwidth) \
-int decode_exi_type_integer##bitwidth(exi_bitstream_t* stream, int##bitwidth##_t* value) \
-{ \
-    uint32_t eventCode; \
-    int error; \
-\
-    error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode); \
-    if (error == 0) \
-    { \
-        if (eventCode == 0) \
-        { \
-            error = exi_basetypes_decoder_integer_##bitwidth(stream, value); \
-        } \
-        else \
-        { \
-            /* Second level event is not supported */ \
-            error = EXI_ERROR__UNSUPPORTED_SUB_EVENT; \
-        } \
-    } \
-\
-    /* if nothing went wrong, the error of last decoding is evaluated here */ \
-    if (error == 0) \
-    { \
-        /* test EE for simple element */ \
-        error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode); \
-        if (error == 0) \
-        { \
-            if(eventCode != 0) \
-            { \
-                /* deviants are not supported or also typecast and nillable */ \
-                error = EXI_ERROR__DEVIANTS_NOT_SUPPORTED; \
-            } \
-        } \
-    } \
-\
-    return error; \
+{% for size in [8, 16, 32, 64] -%}
+int decode_exi_type_integer{{ size }}(exi_bitstream_t* stream, int{{ size }}_t* value)
+{
+    uint32_t eventCode;
+    int error;
+
+    error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
+    if (error == 0)
+    {
+        if (eventCode == 0)
+        {
+            error = exi_basetypes_decoder_integer_{{ size }}(stream, value);
+        }
+        else
+        {
+            /* Second level event is not supported */
+            error = EXI_ERROR__UNSUPPORTED_SUB_EVENT;
+        }
+    }
+
+    /* if nothing went wrong, the error of last decoding is evaluated here */
+    if (error == 0)
+    {
+        /* test EE for simple element */
+        error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
+        if (error == 0)
+        {
+            if(eventCode != 0)
+            {
+                /* deviants are not supported or also typecast and nillable */
+                error = EXI_ERROR__DEVIANTS_NOT_SUPPORTED;
+            }
+        }
+    }
+
+    return error;
 }
-#endif /* BUILD_DECODE_EXI_TYPE_INTEGER_N */
 
-BUILD_DECODE_EXI_TYPE_INTEGER_N(8)
-BUILD_DECODE_EXI_TYPE_INTEGER_N(16)
-BUILD_DECODE_EXI_TYPE_INTEGER_N(32)
-BUILD_DECODE_EXI_TYPE_INTEGER_N(64)
+{% endfor -%}
 
-#ifndef BUILD_DECODE_EXI_TYPE_UINT_N
-#define BUILD_DECODE_EXI_TYPE_UINT_N(bitwidth) \
-int decode_exi_type_uint##bitwidth(exi_bitstream_t* stream, uint##bitwidth##_t* value) \
-{ \
-    uint32_t eventCode; \
-    int error; \
-\
-    error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode); \
-    if (error == 0) \
-    { \
-        if (eventCode == 0) \
-        { \
-            error = exi_basetypes_decoder_uint_##bitwidth(stream, value); \
-        } \
-        else \
-        { \
-            /* Second level event is not supported */ \
-            error = EXI_ERROR__UNSUPPORTED_SUB_EVENT; \
-        } \
-    } \
-\
-    /* if nothing went wrong, the error of last decoding is evaluated here */ \
-    if (error == 0) \
-    { \
-        /* test EE for simple element */ \
-        error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode); \
-        if (error == 0) \
-        { \
-            if (eventCode != 0) \
-            { \
-                /* deviants are not supported or also typecast and nillable */ \
-                error = EXI_ERROR__DEVIANTS_NOT_SUPPORTED; \
-            } \
-        } \
-    } \
-\
-    return error; \
+{% for size in [8, 16, 32, 64] %}
+int decode_exi_type_uint{{ size }}(exi_bitstream_t* stream, uint{{ size }}_t* value)
+{
+    uint32_t eventCode;
+    int error;
+
+    error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
+    if (error == 0)
+    {
+        if (eventCode == 0)
+        {
+            error = exi_basetypes_decoder_uint_{{ size }}(stream, value);
+        }
+        else
+        {
+            /* Second level event is not supported */
+            error = EXI_ERROR__UNSUPPORTED_SUB_EVENT;
+        }
+    }
+
+    /* if nothing went wrong, the error of last decoding is evaluated here */
+    if (error == 0)
+    {
+        /* test EE for simple element */
+        error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
+        if (error == 0)
+        {
+            if (eventCode != 0)
+            {
+                /* deviants are not supported or also typecast and nillable */
+                error = EXI_ERROR__DEVIANTS_NOT_SUPPORTED;
+            }
+        }
+    }
+
+    return error;
 }
-#endif /* BUILD_DECODE_EXI_TYPE_UINT_N */
-
-BUILD_DECODE_EXI_TYPE_UINT_N(8)
-BUILD_DECODE_EXI_TYPE_UINT_N(16)
-BUILD_DECODE_EXI_TYPE_UINT_N(32)
-BUILD_DECODE_EXI_TYPE_UINT_N(64)
+{% endfor -%}
 {% endblock %}

--- a/src/input/code_templates/c/static_code/exi_types_decoder.h.jinja
+++ b/src/input/code_templates/c/static_code/exi_types_decoder.h.jinja
@@ -18,84 +18,27 @@
  */
 int decode_exi_type_hex_binary(exi_bitstream_t* stream, uint16_t* value_len, uint8_t* value_buffer, size_t value_buffer_size);
 
+{% for size in [8, 16, 32, 64] -%}
 /**
- * \brief       Decode 8-bit integer
+ * \brief       Decode {{ size }}-bit integer
  *
  * \param       stream              EXI bitstream
- * \param       value               int8_t (out) decoded value
+ * \param       value               int{{ size }}_t (out) decoded value
  * \return                          Error-Code <> 0, if no error 0
  *
  */
-int decode_exi_type_integer8(exi_bitstream_t* stream, int8_t* value);
+int decode_exi_type_integer{{ size }}(exi_bitstream_t* stream, int{{ size }}_t* value);
 
+{% endfor -%}
+{% for size in [8, 16, 32, 64] %}
 /**
- * \brief       Decode 16-bit integer
+ * \brief       Decode {{ size }}-bit unsigned integer
  *
  * \param       stream              EXI bitstream
- * \param       value               int16_t (out) decoded value
+ * \param       value               uint{{ size }}_t (out) decoded value
  * \return                          Error-Code <> 0, if no error 0
  *
  */
-int decode_exi_type_integer16(exi_bitstream_t* stream, int16_t* value);
-
-/**
- * \brief       Decode 32-bit integer
- *
- * \param       stream              EXI bitstream
- * \param       value               int32_t (out) decoded value
- * \return                          Error-Code <> 0, if no error 0
- *
- */
-int decode_exi_type_integer32(exi_bitstream_t* stream, int32_t* value);
-
-/**
- * \brief       Decode 64-bit integer
- *
- * \param       stream              EXI bitstream
- * \param       value               int64_t (out) decoded value
- * \return                          Error-Code <> 0, if no error 0
- *
- */
-int decode_exi_type_integer64(exi_bitstream_t* stream, int64_t* value);
-
-/**
- * \brief       Decode 8-bit unsigned integer
- *
- * \param       stream              EXI bitstream
- * \param       value               uint8_t (out) decoded value
- * \return                          Error-Code <> 0, if no error 0
- *
- */
-int decode_exi_type_uint8(exi_bitstream_t* stream, uint8_t* value);
-
-/**
- * \brief       Decode 16-bit unsigned integer
- *
- * \param       stream              EXI bitstream
- * \param       value               uint16_t (out) decoded value
- * \return                          Error-Code <> 0, if no error 0
- *
- */
-int decode_exi_type_uint16(exi_bitstream_t* stream, uint16_t* value);
-
-/**
- * \brief       Decode 32-bit unsigned integer
- *
- * \param       stream              EXI bitstream
- * \param       value               uint32_t (out) decoded value
- * \return                          Error-Code <> 0, if no error 0
- *
- */
-int decode_exi_type_uint32(exi_bitstream_t* stream, uint32_t* value);
-
-/**
- * \brief       Decode 64-bit unsigned integer
- *
- * \param       stream              EXI bitstream
- * \param       value               uint64_t (out) decoded value
- * \return                          Error-Code <> 0, if no error 0
- *
- */
-int decode_exi_type_uint64(exi_bitstream_t* stream, uint64_t* value);
-
+int decode_exi_type_uint{{ size }}(exi_bitstream_t* stream, uint{{ size }}_t* value);
+{% endfor -%}
 {% endblock %}


### PR DESCRIPTION
Improve the generated C code by better use of templates.

In the EXI stream codec, implement decode_exi_type_{uint,integer}{8,16,32,64} with Jinja macros instead of C preprocessor macros. This increases debuggability, as actual C code lines are available for all created executable code. The size of the executable code is not changed.

In the decoder and encoder, generate empty C functions via use of a new template, instead of directly within the generator.

At the same time, mark unused variables in these functions within this template, to avoid warnings regarding them.

Co-authored-by: Moritz Barsnick <moritz.barsnick@chargebyte.com>
Signed-off-by: Moritz Barsnick <moritz.barsnick@chargebyte.com>