### PR TITLE
Decoder/Encoder: do not read/write additional START and END bits for attributes

### DIFF
--- a/src/cbexigen/decoder_classes.py
+++ b/src/cbexigen/decoder_classes.py
@@ -92,6 +92,8 @@ class ExiDecoderCode(ExiBaseCoderCode):
     # ---------------------------------------------------------------------------
     def __get_content_decode_hex_binary(self, element_typename, detail: ElementGrammarDetail, level):
         decode_comment = '// decode exi type: hexBinary'
+        if detail.particle.is_attribute:
+            decode_comment += ' (Attribute)'
         if detail.particle.parent_has_choice_sequence:
             type_value = f'{element_typename}->choice_{detail.particle.parent_choice_sequence_number}.{detail.particle.name}'
             type_content = type_value + f'.{detail.particle.value_parameter_name}'
@@ -117,6 +119,8 @@ class ExiDecoderCode(ExiBaseCoderCode):
 
     def __get_content_decode_base64_binary(self, element_typename, detail: ElementGrammarDetail, level):
         decode_comment = '// decode exi type: base64Binary'
+        if detail.particle.is_attribute:
+            decode_comment += ' (Attribute)'
         if detail.particle.parent_has_choice_sequence:
             type_value = f'{element_typename}->choice_{detail.particle.parent_choice_sequence_number}.{detail.particle.name}'
             type_content = type_value + f'.{detail.particle.value_parameter_name}'
@@ -146,6 +150,8 @@ class ExiDecoderCode(ExiBaseCoderCode):
 
     def __get_content_decode_boolean(self, element_typename, detail: ElementGrammarDetail, level):
         decode_comment = '// decode: boolean'
+        if detail.particle.is_attribute:
+            decode_comment += ' (Attribute)'
         type_value = f'{element_typename}->{detail.particle.name}'
         next_grammar_id = detail.next_grammar
 
@@ -167,6 +173,8 @@ class ExiDecoderCode(ExiBaseCoderCode):
             decode_comment = '// decode: unsigned byte (restricted integer)'
         else:
             decode_comment = '// decode: byte (restricted integer)'
+        if detail.particle.is_attribute:
+            decode_comment += ' (Attribute)'
         temp = self.generator.get_template('DecodeTypeRestrictedInt.jinja')
         decode_content = temp.render(decode_comment=decode_comment,
                                      bits_to_decode=8,
@@ -181,6 +189,8 @@ class ExiDecoderCode(ExiBaseCoderCode):
 
     def __get_content_decode_restricted(self, element_typename, detail: ElementGrammarDetail, level):
         decode_comment = '// decode: restricted integer (4096 or fewer values)'
+        if detail.particle.is_attribute:
+            decode_comment += ' (Attribute)'
         type_value = f'{element_typename}->{detail.particle.name}'
         type_offset = detail.particle.min_value
         next_grammar_id = detail.next_grammar
@@ -207,6 +217,8 @@ class ExiDecoderCode(ExiBaseCoderCode):
         else:
             template_file = 'DecodeTypeShort.jinja'
             decode_comment = '// decode: short'
+        if detail.particle.is_attribute:
+            decode_comment += ' (Attribute)'
         temp = self.generator.get_template(template_file)
 
         decode_content = temp.render(decode_comment=decode_comment,
@@ -253,6 +265,8 @@ class ExiDecoderCode(ExiBaseCoderCode):
         else:
             template_file = 'DecodeTypeInt.jinja'
             decode_comment = '// decode: int'
+        if detail.particle.is_attribute:
+            decode_comment += ' (Attribute)'
         temp = self.generator.get_template(template_file)
         decode_content = temp.render(decode_comment=decode_comment,
                                      type_value=type_value,
@@ -272,6 +286,8 @@ class ExiDecoderCode(ExiBaseCoderCode):
         else:
             template_file = 'DecodeTypeLongInt.jinja'
             decode_comment = '// decode: long int'
+        if detail.particle.is_attribute:
+            decode_comment += ' (Attribute)'
         temp = self.generator.get_template(template_file)
         decode_content = temp.render(decode_comment=decode_comment,
                                      type_value=type_value,
@@ -283,6 +299,8 @@ class ExiDecoderCode(ExiBaseCoderCode):
 
     def __get_content_decode_string(self, element_typename, detail: ElementGrammarDetail, level):
         decode_comment = '// decode: string (len, characters)'
+        if detail.particle.is_attribute:
+            decode_comment += ' (Attribute)'
         type_value = f'{element_typename}->{detail.particle.name}'
         type_length = type_value + f'.{detail.particle.length_parameter_name}'
         type_chars = type_value + f'.{detail.particle.value_parameter_name}'
@@ -296,6 +314,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
                                      type_chars=type_chars,
                                      type_chars_size=type_chars_size,
                                      type_option=detail.particle.is_optional,
+                                     type_attribute=detail.particle.is_attribute,
                                      next_grammar_id=next_grammar_id,
                                      indent=self.indent, level=level)
 
@@ -303,6 +322,8 @@ class ExiDecoderCode(ExiBaseCoderCode):
 
     def __get_content_decode_element_array(self, element_typename, detail: ElementGrammarDetail, level):
         decode_comment = '// decode: element array'
+        if detail.particle.is_attribute:
+            decode_comment += ' (Attribute)'
         type_array = f'{element_typename}->{detail.particle.name}.{detail.particle.value_parameter_name}'
         type_array_len = f'{element_typename}->{detail.particle.name}.{detail.particle.length_parameter_name}'
         decode_fn = f'{CONFIG_PARAMS["decode_function_prefix"]}{detail.particle.prefixed_type}'
@@ -338,6 +359,8 @@ class ExiDecoderCode(ExiBaseCoderCode):
 
     def __get_content_decode_element(self, element_typename, detail: ElementGrammarDetail, level):
         decode_comment = '// decode: element'
+        if detail.particle.is_attribute:
+            decode_comment += ' (Attribute)'
         decode_fn = f'{CONFIG_PARAMS["decode_function_prefix"]}{detail.particle.prefixed_type}'
         type_value = f'{element_typename}->{detail.particle.name}'
         next_grammar_id = detail.next_grammar
@@ -354,6 +377,8 @@ class ExiDecoderCode(ExiBaseCoderCode):
 
     def __get_content_decode_enum_array(self, element_typename, detail: ElementGrammarDetail, level):
         decode_comment = '// decode: enum array'
+        if detail.particle.is_attribute:
+            decode_comment += ' (Attribute)'
         type_value = f'{element_typename}->{detail.particle.name}.{detail.particle.value_parameter_name}'
         type_array_len = f'{element_typename}->{detail.particle.name}.{detail.particle.length_parameter_name}'
         type_enum = detail.particle.prefixed_type
@@ -374,6 +399,8 @@ class ExiDecoderCode(ExiBaseCoderCode):
 
     def __get_content_decode_enum(self, element_typename, detail: ElementGrammarDetail, level):
         decode_comment = '// decode: enum'
+        if detail.particle.is_attribute:
+            decode_comment += ' (Attribute)'
         type_value = f'{element_typename}->{detail.particle.name}'
         type_enum = detail.particle.prefixed_type
         next_grammar_id = detail.next_grammar
@@ -382,6 +409,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
         decode_content = temp.render(decode_comment=decode_comment,
                                      bits_to_decode=detail.particle.bit_count_for_coding,
                                      type_option=detail.particle.is_optional,
+                                     type_attribute=detail.particle.is_attribute,
                                      type_value=type_value,
                                      type_enum=type_enum,
                                      next_grammar_id=next_grammar_id,

--- a/src/cbexigen/encoder_classes.py
+++ b/src/cbexigen/encoder_classes.py
@@ -233,6 +233,7 @@ class ExiEncoderCode(ExiBaseCoderCode):
         content = temp.render(length_parameter=length_parameter,
                               value_parameter=value_parameter,
                               size_parameter=size_parameter,
+                              type_attribute=detail.particle.is_attribute,
                               next_grammar=detail.next_grammar,
                               indent=self.indent, level=level)
 
@@ -297,6 +298,7 @@ class ExiEncoderCode(ExiBaseCoderCode):
         temp = self.generator.get_template('EncodeTypeEnum.jinja')
         content = temp.render(value_parameter=value_parameter,
                               bits_to_encode=bits_to_encode,
+                              type_attribute=detail.particle.is_attribute,
                               next_grammar=detail.next_grammar,
                               indent=self.indent, level=level)
 

--- a/src/input/code_templates/c/decoder/DecodeTypeEnum.jinja
+++ b/src/input/code_templates/c/decoder/DecodeTypeEnum.jinja
@@ -1,8 +1,12 @@
 {{ indent * level }}{{ decode_comment }}
+{%- if type_attribute == 0 %}
 {{ indent * level }}error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
 {{ indent * level }}if (error == 0)
 {{ indent * level }}{
 {{ indent * (level + 1) }}if (eventCode == 0)
+{%- else %}
+{%- set level = level - 1 %}
+{%- endif %}
 {{ indent * (level + 1) }}{
 {{ indent * (level + 2) }}uint32_t value;
 {{ indent * (level + 2) }}error = exi_basetypes_decoder_nbit_uint(stream, {{ bits_to_decode }}, &value);
@@ -14,6 +18,7 @@
 {%- endif %}
 {{ indent * (level + 2) }}}
 {{ indent * (level + 1) }}}
+{%- if type_attribute == 0 %}
 {{ indent * (level + 1) }}else
 {{ indent * (level + 1) }}{
 {{ indent * (level + 2) }}// second level event is not supported
@@ -38,3 +43,9 @@
 {{ indent * (level + 2) }}}
 {{ indent * (level + 1) }}}
 {{ indent * level }}}
+{%- else %}
+{%- if type_option == 1 %}
+{{ indent * (level + 1) }}{{ type_value }}_isUsed = 1u;
+{%- endif %}
+{{ indent * (level + 1) }}grammar_id = {{ next_grammar_id }};
+{%- endif %}

--- a/src/input/code_templates/c/decoder/DecodeTypeString.jinja
+++ b/src/input/code_templates/c/decoder/DecodeTypeString.jinja
@@ -1,9 +1,13 @@
 {{ indent * level }}{{ decode_comment }}
+{%- if type_attribute == 0 %}
 {{ indent * level }}error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
 {{ indent * level }}if (error == 0)
 {{ indent * level }}{
 {{ indent * (level + 1) }}if (eventCode == 0)
 {{ indent * (level + 1) }}{
+{%- else %}
+{%- set level = level - 2 %}
+{%- endif %}
 {{ indent * (level + 2) }}error = exi_basetypes_decoder_uint_16(stream, &{{ type_length }});
 {{ indent * (level + 2) }}if (error == 0)
 {{ indent * (level + 2) }}{
@@ -19,6 +23,7 @@
 {{ indent * (level + 4) }}error = EXI_ERROR__STRINGVALUES_NOT_SUPPORTED;
 {{ indent * (level + 3) }}}
 {{ indent * (level + 2) }}}
+{%- if type_attribute == 0 %}
 {{ indent * (level + 1) }}}
 {{ indent * (level + 1) }}else
 {{ indent * (level + 1) }}{
@@ -47,3 +52,9 @@
 {{ indent * (level + 2) }}}
 {{ indent * (level + 1) }}}
 {{ indent * level }}}
+{%- else %}
+{%- if type_option == 1 %}
+{{ indent * (level + 1) }}{{ type_value }}_isUsed = 1u;
+{%- endif %}
+{{ indent * (level + 2) }}grammar_id = {{ next_grammar_id }};
+{%- endif %}

--- a/src/input/code_templates/c/encoder/EncodeTypeEnum.jinja
+++ b/src/input/code_templates/c/encoder/EncodeTypeEnum.jinja
@@ -1,9 +1,14 @@
+{%- if type_attribute == 0 -%}
 {{ indent * level }}error = exi_basetypes_encoder_nbit_uint(stream, 1, 0);
 {{ indent * level }}if (error == EXI_ERROR__NO_ERROR)
 {{ indent * level }}{
+{%- else -%}
+{%- set level = level - 1 %}
+{%- endif %}
 {{ indent * (level + 1) }}error = exi_basetypes_encoder_nbit_uint(stream, {{ bits_to_encode }}, {{ value_parameter }});
 {{ indent * (level + 1) }}if (error == EXI_ERROR__NO_ERROR)
 {{ indent * (level + 1) }}{
+{%- if type_attribute == 0 %}
 {{ indent * (level + 2) }}// encode END Element
 {{ indent * (level + 2) }}error = exi_basetypes_encoder_nbit_uint(stream, 1, 0);
 {{ indent * (level + 2) }}if (error == EXI_ERROR__NO_ERROR)
@@ -12,3 +17,7 @@
 {{ indent * (level + 2) }}}
 {{ indent * (level + 1) }}}
 {{ indent * level }}}
+{%- else %}
+{{ indent * (level + 2) }}grammar_id = {{ next_grammar }};
+{{ indent * (level + 1) }}}
+{%- endif %}

--- a/src/input/code_templates/c/encoder/EncodeTypeString.jinja
+++ b/src/input/code_templates/c/encoder/EncodeTypeString.jinja
@@ -1,6 +1,10 @@
+{%- if type_attribute == 0 %}
 {{ indent * level }}error = exi_basetypes_encoder_nbit_uint(stream, 1, 0);
 {{ indent * level }}if (error == EXI_ERROR__NO_ERROR)
 {{ indent * level }}{
+{%- else %}
+{%- set level = level - 1 %}
+{%- endif %}
 {{ indent * (level + 1) }}// string should not be found in table, so add 2
 {{ indent * (level + 1) }}error = exi_basetypes_encoder_uint_16(stream, (uint16_t)({{ length_parameter }} + 2));
 {{ indent * (level + 1) }}if (error == EXI_ERROR__NO_ERROR)
@@ -8,6 +12,7 @@
 {{ indent * (level + 2) }}error = exi_basetypes_encoder_characters(stream, {{ length_parameter }}, {{ value_parameter }}, {{ size_parameter }});
 {{ indent * (level + 2) }}if (error == EXI_ERROR__NO_ERROR)
 {{ indent * (level + 2) }}{
+{%- if type_attribute == 0 %}
 {{ indent * (level + 3) }}// encode END Element
 {{ indent * (level + 3) }}error = exi_basetypes_encoder_nbit_uint(stream, 1, 0);
 {{ indent * (level + 3) }}if (error == EXI_ERROR__NO_ERROR)
@@ -17,3 +22,8 @@
 {{ indent * (level + 2) }}}
 {{ indent * (level + 1) }}}
 {{ indent * level }}}
+{%- else %}
+{{ indent * (level + 3) }}grammar_id = {{ next_grammar }};
+{{ indent * (level + 2) }}}
+{{ indent * (level + 1) }}}
+{%- endif %}


### PR DESCRIPTION
Attributes have no SE, EE.

Currently, this is only applied to string and enum attributes, as we apparently only have string attributes in all supported schemas, coming from their included xmldsig, as well as an enum attribute in DIN 70121's ParameterType.

Probably, this method also needs to be generically applied to all other types which can be attributes. Other types of attributes than string or enum do not occur in any of the supported schemas (yet).

Also print the attribute property in decoder comments.