### PR TITLE
Fix for occurrence of single particle sequences

### DIFF
--- a/src/cbexigen/elementData.py
+++ b/src/cbexigen/elementData.py
@@ -372,6 +372,8 @@ class ElementData:
             if particle.parent_has_sequence:
                 comment_part += f'(was {particle.min_occurs_old}, {particle.max_occurs_old})'
                 comment_part += f'(seq. {particle.parent_sequence})'
+            elif particle.parent_model_changed_restrictions:
+                comment_part += f'(old {particle.min_occurs_old}, {particle.max_occurs_old})'
 
             comment_parts.append(comment_part)
 


### PR DESCRIPTION
If a sequence has only one particle and the sequence is optional, the particle has to inherit the occurrence of the sequence.

The particle comment is adjusted.
It shows now also the old occurrence.