### PR TITLE
Move some C code from Encoder class to code templates

### DIFF
--- a/src/cbexigen/encoder_classes.py
+++ b/src/cbexigen/encoder_classes.py
@@ -321,14 +321,23 @@ class ExiEncoderCode(ExiBaseCoderCode):
 
         return content
 
+    def __get_content_encode_not_implemented(self, element_typename, detail: ElementGrammarDetail, level):
+        encode_comment = f"// tbd! decode: '{detail.particle.type_short}', " + \
+            f"base type '{detail.particle.typename}'"
+
+        temp = self.generator.get_template('EncodeTypeNotImplemented.jinja')
+        content = temp.render(encode_comment=encode_comment,
+                              indent=self.indent, level=level)
+
+        return content
+
     def __get_type_content(self, grammar: ElementGrammar, detail: ElementGrammarDetail, level):
         if detail.particle is None:
             temp = self.generator.get_template('BaseDecodeEndElement.jinja')
             return temp.render(next_grammar=detail.next_grammar, indent=self.indent, level=level)
 
-        type_content = f"{self.indent * level}// tbd! decode: '{detail.particle.type_short}'" \
-                       f", base type '{detail.particle.typename}'\n"
-        type_content += f"{self.indent * level}error = EXI_ERROR__ENCODER_NOT_IMPLEMENTED;\n"
+        # default content for types not covered below
+        type_content = self.__get_content_encode_not_implemented(grammar.element_typename, detail, level)
 
         # If the associated schema datatype is directly or indirectly derived from xsd:integer
         # and the bounded range determined by its minInclusiveXS2, minExclusiveXS2, maxInclusiveXS2

--- a/src/cbexigen/encoder_classes.py
+++ b/src/cbexigen/encoder_classes.py
@@ -407,7 +407,7 @@ class ExiEncoderCode(ExiBaseCoderCode):
         content = ''
 
         event_comment = f'// Event: {detail.flag}; '
-        event_comment += f'set next={detail.next_grammar}'
+        event_comment += f'next={detail.next_grammar}'
         temp = self.generator.get_template('EncodeEventEndElement.jinja')
         content += temp.render(bits_to_write=bits_to_write,
                                value_to_write=detail.event_index,
@@ -495,14 +495,11 @@ class ExiEncoderCode(ExiBaseCoderCode):
                                        indent=self.indent, level=level)
             else:
                 # unsupported particle which appears in the event list
-                event_comment = f'// Event: None (index={detail.event_index}); next={detail.next_grammar}'
-                type_content = str(self.indent * 4) + 'error = EXI_ERROR__NO_ERROR;\n'
-                type_content += str(self.indent * 4) + 'done = 1;'
+                event_comment = f'// Event: {detail.particle_name} (index={detail.event_index}); next={detail.next_grammar}'
 
                 temp = self.generator.get_template('EncodeEventOptionalElementNone.jinja')
                 content += temp.render(option=option,
                                        event_comment=event_comment,
-                                       type_content=type_content,
                                        indent=self.indent, level=level)
 
         content += '\n'

--- a/src/input/code_templates/c/encoder/EncodeEventOptionalElementNone.jinja
+++ b/src/input/code_templates/c/encoder/EncodeEventOptionalElementNone.jinja
@@ -7,5 +7,6 @@
 {%- endif %}
 {{ indent * level }}{
 {{ indent * (level + 1) }}{{ event_comment }}
-{{ type_content }}
+{{ indent * (level + 1) }}error = EXI_ERROR__ENCODER_NOT_IMPLEMENTED;
+{{ indent * (level + 1) }}done = 1;
 {{ indent * level }}}

--- a/src/input/code_templates/c/encoder/EncodeTypeNotImplemented.jinja
+++ b/src/input/code_templates/c/encoder/EncodeTypeNotImplemented.jinja
@@ -1,0 +1,2 @@
+{{ indent * level }}{{ encode_comment }}
+{{ indent * level }}error = EXI_ERROR__ENCODER_NOT_IMPLEMENTED;


### PR DESCRIPTION
While the Encoder and Decoder classes still have some C-ish constructs, this commit series tries to remove obvious C constructs to templates.