### PR TITLE
Handle wildcard element grammar events for PnC

### DIFF
--- a/src/cbexigen/base_coder_classes.py
+++ b/src/cbexigen/base_coder_classes.py
@@ -397,6 +397,13 @@ class ExiBaseCoderCode:
                         grammar.details.append(ElementGrammarDetail(flag=GrammarFlag.END))
 
             def _add_particle_or_choice_list_to_details(element, grammar, particle, previous_choice_list):
+                """
+                If a particle is part of a choice group, this adds all the group's particles
+                the the grammar at once, and remembers which group was being handled, so that
+                the subsequent particles aren't added again.
+
+                Otherwise, it just adds the particle.
+                """
                 choice_list = self._get_choice_options(element, particle)
                 if choice_list:
                     if choice_list[1] != previous_choice_list:

--- a/src/cbexigen/base_coder_classes.py
+++ b/src/cbexigen/base_coder_classes.py
@@ -233,6 +233,24 @@ class ExiBaseCoderCode:
 
         return result
 
+    @staticmethod
+    def _get_choice_sequence(element: ElementData, particle: Particle) -> []:
+        """
+        Return an ordered list of all particles belonging to the same choice sequence as
+        the given particle.
+        """
+        if particle.parent_has_choice_sequence:
+            for choice_obj in element.choices:
+                choice_sequence = choice_obj.choice_sequences[particle.parent_choice_sequence_number - 1]
+                for choice_item in choice_sequence:
+                    if particle.name == choice_item[0]:  # first element is name, second element is index
+                        li: list[Particle] = [element.particle_from_name(x[0]) for x in choice_sequence]
+                        return li
+            log_write_error(f"failed to find choice sequence for of {particle.name}")
+
+        # particle is not in a choice sequence, or fallback on failure to find
+        return []
+
     def _get_choice_options(self, element: ElementData, particle: Particle):
         """
         Return a list containing:
@@ -332,23 +350,6 @@ class ExiBaseCoderCode:
                         return True
             return False
 
-        def _get_choice_sequence(element: ElementData, particle: Particle) -> []:
-            """
-            Return an ordered list of all particles belonging to the same choice sequence as
-            the given particle.
-            """
-            if particle.parent_has_choice_sequence:
-                for choice_obj in element.choices:
-                    choice_sequence = choice_obj.choice_sequences[particle.parent_choice_sequence_number - 1]  # list of [name, index] list
-                    for choice_item in choice_sequence:
-                        if particle.name == choice_item[0]:  # first element is name, second element is index
-                            li: list[Particle] = [element.particle_from_name(x[0]) for x in choice_sequence]
-                            return li
-                log_write_error(f"failed to find choice sequence for of {particle.name}")
-
-            # particle is not in a choice sequence, or fallback on failure to find
-            return []
-
         def _debug_element_particle_properties(element: ElementData):
             particle: Particle
             for particle in element.particles:
@@ -375,7 +376,7 @@ class ExiBaseCoderCode:
                     log_write(f"\tmax_occurs_old: {particle.max_occurs_old}")
                 if particle.parent_has_choice_sequence:
                     log_write(f"\tparent is in a sequence which is choice, number {particle.parent_choice_sequence_number}")
-                    log_write([x.name if x is not None else '' for x in _get_choice_sequence(element, particle)])
+                    log_write([x.name if x is not None else '' for x in self._get_choice_sequence(element, particle)])
 
         # _debug_element_particle_properties(element)
 

--- a/src/cbexigen/base_coder_classes.py
+++ b/src/cbexigen/base_coder_classes.py
@@ -499,8 +499,15 @@ class ExiBaseCoderCode:
                     log_write(f"\tmax_occurs_old: {particle.max_occurs_old}")
                 if particle.parent_has_choice_sequence:
                     log_write("\tis in a sequence which is choice, " +
-                              f"number {particle.parent_choice_sequence_number}")
-                    log_write([x.name if x is not None else '' for x in self._get_choice_sequence(element, particle)])
+                              f"number {particle.parent_choice_sequence_number}:")
+                    log_write("\t\t" + repr([x.name if x is not None else '' for x in self._get_choice_sequence(element, particle)]))
+                    choice_options = self.ChoiceOptions(element, particle)
+                    num_part_to_skip = choice_options.number_of_particles_to_skip
+                    if num_part_to_skip:
+                        log_write(f"\tparticles to skip: {choice_options.number_of_particles_to_skip}")
+                    if choice_options.particles:
+                        log_write("\tis in a resulting choice, " +
+                                  f"{choice_options.item_names}")
 
         # _debug_element_particle_properties(element)
 

--- a/src/cbexigen/decoder_classes.py
+++ b/src/cbexigen/decoder_classes.py
@@ -538,14 +538,12 @@ class ExiDecoderCode(ExiBaseCoderCode):
         event_content = ''
 
         if grammar.details[0].flag != GrammarFlag.ERROR:
-            end_id = -1
             detail: ElementGrammarDetail = None
-            for index, detail in enumerate(grammar.details):
+            for detail in grammar.details:
                 if detail.flag == GrammarFlag.END:
-                    end_id = index
-                    continue
-
-                if detail.particle is not None:
+                    event_comment = f'// Event: {detail.flag}; ' + \
+                                    f'next={detail.next_grammar}'
+                elif detail.particle is not None:
                     event_comment = f'// Event: {detail.flag} ({detail.particle.name}, ' + \
                                     f'{detail.particle.type_short} ({detail.particle.typename})); ' + \
                                     f'next={detail.next_grammar}'
@@ -563,17 +561,6 @@ class ExiDecoderCode(ExiBaseCoderCode):
                                              # type_parameter=type_parameter,
                                              indent=self.indent, level=level)
                 event_content += '\n'
-
-            if end_id >= 0:
-                event_comment = f'// Event: {grammar.details[end_id].flag}; '
-                event_comment += f'set next={grammar.details[end_id].next_grammar}'
-                temp = self.generator.get_template('BaseDecodeCaseEventId.jinja')
-                event_content += temp.render(event_id=grammar.details[end_id].event_index,
-                                             event_id_comment=event_comment,
-                                             type_content=self.__get_type_content(grammar, grammar.details[end_id], 5),
-                                             indent=self.indent, level=level)
-
-            event_content += '\n'
 
         return self.trim_lf(event_content)
 

--- a/src/cbexigen/elementGrammar.py
+++ b/src/cbexigen/elementGrammar.py
@@ -20,6 +20,7 @@ class ElementGrammarDetail:
     array_index: int = -1
     event_index: int = -1
     next_grammar: int = -1
+    any_is_dummy: bool = True
 
     @property
     def is_optional(self):

--- a/src/input/code_templates/c/SubStructSequence.jinja
+++ b/src/input/code_templates/c/SubStructSequence.jinja
@@ -2,3 +2,4 @@
 {{ indent * level }}struct {
 {{ sequence_content }}
 {{ indent * level }}} {{ sequence_name }};
+{{ indent * level }}unsigned int {{ sequence_name }}_isUsed:1;

--- a/src/input/code_templates/c/decoder/DecodeTypeNoEvent.jinja
+++ b/src/input/code_templates/c/decoder/DecodeTypeNoEvent.jinja
@@ -1,0 +1,2 @@
+{{ indent * level }}{{ decode_comment }}
+{{ indent * level }}error = EXI_ERROR__UNKNOWN_EVENT_FOR_DECODING;

--- a/src/input/code_templates/c/decoder/DecodeTypeNotImplemented.jinja
+++ b/src/input/code_templates/c/decoder/DecodeTypeNotImplemented.jinja
@@ -1,0 +1,2 @@
+{{ indent * level }}{{ decode_comment }}
+{{ indent * level }}error = EXI_ERROR__DECODER_NOT_IMPLEMENTED;

--- a/src/input/code_templates/c/encoder/EncodeEventOptionalElementNoEvent.jinja
+++ b/src/input/code_templates/c/encoder/EncodeEventOptionalElementNoEvent.jinja
@@ -1,0 +1,5 @@
+{{ indent * level }}// ***** //
+{{ indent * level }}//{
+{{ indent * (level + 1) }}{{ event_comment }}
+{{ indent * level }}//{
+{{ indent * level }}// ***** //


### PR DESCRIPTION
Wildcard elements such as "##any" and "##other" create a different set of events. Even though we do not need to encode or decode these elements, the counting of event codes needs to take them into consideration.
