### PR TITLE
Add more array optimizations to config for iso-20

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -60,6 +60,9 @@ iso20_array_optimizations = {
     # gdb's stack overflows on the original struct site - no other
     # reason to restrict this currently
     'PriceRuleStackType': 64,
+    # Workaround for missing loop implementation of large arrays (https://github.com/EVerest/cbexigen/issues/28).
+    'ParameterSetType': 5,
+    'ParameterType': 5,
 }
 
 # general C code style


### PR DESCRIPTION
This is a workaround for
https://github.com/EVerest/cbexigen/issues/28