### PR TITLE
Fix de- and encoding of empty elements

### DIFF
--- a/src/cbexigen/decoder_classes.py
+++ b/src/cbexigen/decoder_classes.py
@@ -682,7 +682,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
                                    indent=self.indent, level=1)
             content += '\n\n'
         else:
-            temp = self.generator.get_template('BaseEmptyFunction.jinja')
+            temp = self.generator.get_template('DecodeEmptyFunction.jinja')
             content += temp.render(element_comment=element.element_comment,
                                    function_name=CONFIG_PARAMS['decode_function_prefix'] + element.prefixed_type,
                                    struct_type=element.prefixed_type, parameter_name=typename,

--- a/src/cbexigen/encoder_classes.py
+++ b/src/cbexigen/encoder_classes.py
@@ -693,7 +693,7 @@ class ExiEncoderCode(ExiBaseCoderCode):
                                    indent=self.indent, level=1)
             content += '\n\n'
         else:
-            temp = self.generator.get_template('BaseEmptyFunction.jinja')
+            temp = self.generator.get_template('EncodeEmptyFunction.jinja')
             content += temp.render(element_comment=element.element_comment,
                                    function_name=CONFIG_PARAMS['encode_function_prefix'] + element.prefixed_type,
                                    struct_type=element.prefixed_type, parameter_name=typename,

--- a/src/input/code_templates/c/decoder/DecodeEmptyFunction.jinja
+++ b/src/input/code_templates/c/decoder/DecodeEmptyFunction.jinja
@@ -1,0 +1,25 @@
+{{ element_comment }}
+static int {{ function_name }}(exi_bitstream_t* stream, struct {{ struct_type }}* {{ parameter_name }}) {
+{{ indent * level }}// Element has no particles, so the function just decodes END Element
+{{ indent * level }}(void){{ parameter_name }};
+{{ indent * level }}uint32_t eventCode;
+
+{%- if add_debug_code == 1 %}
+
+{{ indent * level }}if (stream->status_callback)
+{{ indent * level }}{
+{{ indent * (level + 1) }}stream->status_callback({{ function_name|upper }}, 0, 0, 0);
+{{ indent * level }}}
+{%- endif %}
+
+{{ indent * level }}int error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
+{{ indent * level }}if (error == 0)
+{{ indent * level }}{
+{{ indent * (level + 1) }}if (eventCode != 0)
+{{ indent * (level + 1) }}{
+{{ indent * (level + 2) }}error = EXI_ERROR__UNKNOWN_EVENT_CODE;
+{{ indent * (level + 1) }}}
+{{ indent * level }}}
+
+{{ indent * level }}return error;
+}

--- a/src/input/code_templates/c/encoder/EncodeEmptyFunction.jinja
+++ b/src/input/code_templates/c/encoder/EncodeEmptyFunction.jinja
@@ -1,0 +1,17 @@
+{{ element_comment }}
+static int {{ function_name }}(exi_bitstream_t* stream, struct {{ struct_type }}* {{ parameter_name }}) {
+{{ indent * level }}// Element has no particles, so the function just encodes END Element
+{{ indent * level }}(void){{ parameter_name }};
+
+{%- if add_debug_code == 1 %}
+
+{{ indent * level }}if (stream->status_callback)
+{{ indent * level }}{
+{{ indent * (level + 1) }}stream->status_callback({{ function_name|upper }}, 0, 0, 0);
+{{ indent * level }}}
+{%- endif %}
+
+{{ indent * level }}int error = exi_basetypes_encoder_nbit_uint(stream, 1, 0);
+
+{{ indent * level }}return error;
+}


### PR DESCRIPTION
The empty elements has to generate an END Element in the exi stream.

New templates were added.
The de- and encoder were adjusted.