### PR TITLE
Encoder/Decoder: encode simple strings without START/END

### DIFF
--- a/src/cbexigen/decoder_classes.py
+++ b/src/cbexigen/decoder_classes.py
@@ -338,6 +338,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
         type_length = type_value + f'.{detail.particle.length_parameter_name}'
         type_chars = type_value + f'.{detail.particle.value_parameter_name}'
         type_chars_size = detail.particle.prefixed_define_for_base_type
+        type_simple = detail.particle.is_attribute or detail.particle.is_simple_content
         next_grammar_id = detail.next_grammar
 
         if detail.particle.max_occurs > 1:
@@ -353,7 +354,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
                                      type_chars=type_chars,
                                      type_chars_size=type_chars_size,
                                      type_option=detail.particle.is_optional,
-                                     type_attribute=detail.particle.is_attribute,
+                                     type_simple=type_simple,
                                      type_array=detail.particle.max_occurs > 1,
                                      type_array_length=f'{element_typename}->{detail.particle.name}.arrayLen',
                                      type_array_define=detail.particle.prefixed_define_for_array,

--- a/src/cbexigen/encoder_classes.py
+++ b/src/cbexigen/encoder_classes.py
@@ -252,6 +252,7 @@ class ExiEncoderCode(ExiBaseCoderCode):
         size_parameter = f'{detail.particle.prefixed_define_for_base_type}'
 
         type_array_index = detail.particle.name + '_currentIndex'
+        type_simple = detail.particle.is_attribute or detail.particle.is_simple_content
         if detail.particle.is_array:
             length_parameter = (f'{element_typename}->{detail.particle.name}'
                                 f'.array[{type_array_index}].{detail.particle.length_parameter_name}')
@@ -262,7 +263,7 @@ class ExiEncoderCode(ExiBaseCoderCode):
         content = temp.render(length_parameter=length_parameter,
                               value_parameter=value_parameter,
                               size_parameter=size_parameter,
-                              type_attribute=detail.particle.is_attribute,
+                              type_simple=type_simple,
                               type_array=detail.particle.is_array,
                               type_array_index=type_array_index,
                               next_grammar=detail.next_grammar,

--- a/src/input/code_templates/c/decoder/DecodeTypeString.jinja
+++ b/src/input/code_templates/c/decoder/DecodeTypeString.jinja
@@ -4,7 +4,7 @@
 {{ indent * level }}{
 {%- set level = level + 1 %}
 {%- endif %}
-{%- if type_attribute == 0 %}
+{%- if type_simple == 0 %}
 {{ indent * level }}error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
 {{ indent * level }}if (error == 0)
 {{ indent * level }}{
@@ -43,7 +43,7 @@
 {{ indent * (level + 4) }}error = EXI_ERROR__STRINGVALUES_NOT_SUPPORTED;
 {{ indent * (level + 3) }}}
 {{ indent * (level + 2) }}}
-{%- if type_attribute == 0 %}
+{%- if type_simple == 0 %}
 {{ indent * (level + 1) }}}
 {{ indent * (level + 1) }}else
 {{ indent * (level + 1) }}{

--- a/src/input/code_templates/c/encoder/EncodeTypeString.jinja
+++ b/src/input/code_templates/c/encoder/EncodeTypeString.jinja
@@ -1,4 +1,4 @@
-{%- if type_attribute == 0 %}
+{%- if type_simple == 0 %}
 {{ indent * level }}error = exi_basetypes_encoder_nbit_uint(stream, 1, 0);
 {{ indent * level }}if (error == EXI_ERROR__NO_ERROR)
 {{ indent * level }}{
@@ -15,7 +15,7 @@
 {%- if type_array == 1 %}
 {{ indent * (level + 3) }}{{ type_array_index }}++;
 {%- endif %}
-{%- if type_attribute == 0 %}
+{%- if type_simple == 0 %}
 {{ indent * (level + 3) }}// encode END Element
 {{ indent * (level + 3) }}error = exi_basetypes_encoder_nbit_uint(stream, 1, 0);
 {{ indent * (level + 3) }}if (error == EXI_ERROR__NO_ERROR)


### PR DESCRIPTION
Simple strings with attached attributes are not complex, and need to be encoded in a more basic manner, such as strings as attributes already are, i.e. without additional START and END bits.

This fixes coding of ISO 15118-2 EMAIDType in CertificateInstallationRes, and possibly others.