### PR TITLE
config, typeDefinitions: allow up to 4 Reference items

### DIFF
--- a/src/cbexigen/typeDefinitions.py
+++ b/src/cbexigen/typeDefinitions.py
@@ -38,7 +38,7 @@ OCCURRENCE_LIMITS_CORRECTED: Dict[str, int] = {
     "RootCertificateID": 5,
     "Transform": 1,
     "SignatureProperty": 1,
-    "Reference": 1,
+    "Reference": 4,
     "PMaxScheduleEntry": 5,
     "KeyName": 1,
     "KeyValue": 1,

--- a/src/config.py
+++ b/src/config.py
@@ -48,6 +48,9 @@ apply_optimizations = 1
 appHand_array_optimizations = {
     'AppProtocolType': 5
 }
+din_array_optimizations = {
+    'ReferenceType': 1
+}
 iso2_array_optimizations = {
     'PMaxScheduleEntryType': 12,
     'SalesTariffEntryType': 12,


### PR DESCRIPTION
The size of the Reference array was previously reduced to 1, which is not sufficient for PnC. According to ISO 15118-2 [V2G2-909], 4 items must be supported.

According to ISO 15118-20, there is no restriction, therefore, this may need to be revisited, and the limit lifted.

For DIN, the restriction remains 1, as PnC is unused.