### PR TITLE
Fix ACDP and WPT code creation

### DIFF
--- a/src/cbexigen/datatype_classes.py
+++ b/src/cbexigen/datatype_classes.py
@@ -370,24 +370,25 @@ class DatatypeHeader:
         return struct_content
 
     def __get_root_content(self):
-        elements = {}
+        elements = []
         comment = '// root elements of EXI doc'
         name = self.parameters['prefix'] + self.config['root_struct_name']
         self.analyzer_data.known_prototypes[name] = self.config['root_parameter_name']
 
+        element: ElementData
         for element in self.analyzer_data.root_elements:
             if self.__is_iso20:
                 # TODO: The following if filters the simple types DigestValue, MgmtData and KeyName.
                 #       So it has to be checked if these types can be ignored here.
                 if element.type_definition == 'complex':
-                    elements[element.prefixed_type] = element.name_short
+                    elements.append((element.prefixed_type, element.name_short))
                     self.analyzer_data.known_prototypes[element.prefixed_type] = element.name_short
             else:
                 if element.base_type == '':
-                    elements[element.prefixed_name] = element.name_short
+                    elements.append((element.prefixed_type, element.name_short))
                     self.analyzer_data.known_prototypes[element.prefixed_name] = element.name_short
                 else:
-                    elements[element.prefixed_type] = element.type_short
+                    elements.append((element.prefixed_type, element.type_short))
                     self.analyzer_data.known_prototypes[element.prefixed_type] = element.type_short
 
         # generate struct for array with length variable

--- a/src/cbexigen/encoder_classes.py
+++ b/src/cbexigen/encoder_classes.py
@@ -469,6 +469,10 @@ class ExiEncoderCode(ExiBaseCoderCode):
         length_parameter = (f'{grammar.element_typename}->{detail.particle.name}'
                             f'.{detail.particle.length_parameter_name}')
 
+        if detail.particle.is_array:
+            length_parameter = (f'{grammar.element_typename}->{detail.particle.name}'
+                                f'.arrayLen')
+
         temp = self.generator.get_template('EncodeEventOptionalArrayElement.jinja')
         content = temp.render(option=option,
                               index_parameter=index_parameter,

--- a/src/input/code_templates/c/BaseStruct.jinja
+++ b/src/input/code_templates/c/BaseStruct.jinja
@@ -1,6 +1,6 @@
 {{ element_comment }}
 struct {{ struct_name }} {
-    {%- for type, name in elements.items() %}
+    {%- for type, name in elements %}
     struct {{ type }} {{ name }};
     {%- endfor %}
 };

--- a/src/input/code_templates/c/BaseStructWithUnionAndUsed.jinja
+++ b/src/input/code_templates/c/BaseStructWithUnionAndUsed.jinja
@@ -1,11 +1,11 @@
 {{ element_comment }}
 struct {{ struct_name }} {
     union {
-        {%- for type, name in elements.items() %}
+        {%- for type, name in elements %}
         struct {{ type }} {{ name }};
         {%- endfor %}
     };
-    {%- for type, name in elements.items() %}
+    {%- for type, name in elements %}
     unsigned int {{ name }}_isUsed:1;
     {%- endfor %}
 };


### PR DESCRIPTION
Two fixes regarding code creation for as of yet unused ISO 15118-20 schemas:

- Fix accidental dropping of ACDP messages due to them having the same type.
- Fix incorrect arrayLen specifier for arrays of base64hex. Affects only WPT. (`Particle`'s attribute `length_parameter_name` does not deliver the correct value.)

To verify, you need to enable code creation for WPT and ACDP in `src/config.py`.