### PR TITLE
fix various cppcheck warnings in generated C code

### DIFF
--- a/src/cbexigen/encoder_classes.py
+++ b/src/cbexigen/encoder_classes.py
@@ -111,10 +111,11 @@ class ExiEncoderCode(ExiBaseCoderCode):
     # generator helper functions
     # ---------------------------------------------------------------------------
     def get_function_declaration(self, element_name, is_forward_declaration):
+        # FIXME convert this to a Jinja template, must correspond exactly to BaseEncodeFunction.jinja
         content = 'static '
         content += 'int ' + self.config['encode_function_prefix'] + self.parameters['prefix'] + element_name + '('
         content += 'exi_bitstream_t* stream, '
-        content += 'struct ' + self.parameters['prefix'] + element_name + '* ' + element_name + ')'
+        content += 'const struct ' + self.parameters['prefix'] + element_name + '* ' + element_name + ')'
 
         if is_forward_declaration:
             content += ';'

--- a/src/input/code_templates/c/BaseEncodeFunction.jinja
+++ b/src/input/code_templates/c/BaseEncodeFunction.jinja
@@ -1,6 +1,6 @@
 {{ element_comment }}
 {{ particle_comment }}
-static int {{ function_name }}(exi_bitstream_t* stream, struct {{ struct_type }}* {{ parameter_name }}) {
+static int {{ function_name }}(exi_bitstream_t* stream, const struct {{ struct_type }}* {{ parameter_name }}) {
 {{ indent * level }}int grammar_id = {{ start_grammar_id }};
 {{ indent * level }}int done = 0;
 {{ indent * level }}int error = 0;

--- a/src/input/code_templates/c/encoder/EncodeEmptyFunction.jinja
+++ b/src/input/code_templates/c/encoder/EncodeEmptyFunction.jinja
@@ -1,5 +1,5 @@
 {{ element_comment }}
-static int {{ function_name }}(exi_bitstream_t* stream, struct {{ struct_type }}* {{ parameter_name }}) {
+static int {{ function_name }}(exi_bitstream_t* stream, const struct {{ struct_type }}* {{ parameter_name }}) {
 {{ indent * level }}// Element has no particles, so the function just encodes END Element
 {{ indent * level }}(void){{ parameter_name }};
 

--- a/src/input/code_templates/c/static_code/exi_basetypes_decoder.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes_decoder.c.jinja
@@ -14,7 +14,6 @@
 static int exi_basetypes_decoder_read_unsigned(exi_bitstream_t* stream, exi_unsigned_t* exi_unsigned)
 {
     const uint8_t MSB = (1u << 7);
-    int error;
 
     int found_sequence_end = 0;
     uint8_t* current_octet = exi_unsigned->octets;
@@ -22,6 +21,7 @@ static int exi_basetypes_decoder_read_unsigned(exi_bitstream_t* stream, exi_unsi
 
     while (exi_unsigned->octets_count < EXI_BASETYPES_MAX_OCTETS_SUPPORTED)
     {
+        int error;
         error = exi_bitstream_read_octet(stream, current_octet);
         if (error != EXI_ERROR__NO_ERROR)
         {
@@ -79,7 +79,6 @@ int exi_basetypes_decoder_bool(exi_bitstream_t* stream, int* value)
  *****************************************************************************/
 int exi_basetypes_decoder_bytes(exi_bitstream_t* stream, size_t bytes_len, uint8_t* bytes, size_t bytes_size)
 {
-    int error;
 
     if (bytes_len > bytes_size)
     {
@@ -90,6 +89,7 @@ int exi_basetypes_decoder_bytes(exi_bitstream_t* stream, size_t bytes_len, uint8
 
     for (size_t n = 0; n < bytes_len; n++)
     {
+        int error;
         error = exi_bitstream_read_octet(stream, current_byte);
         if (error != EXI_ERROR__NO_ERROR)
         {
@@ -347,7 +347,6 @@ int exi_basetypes_decoder_integer_64(exi_bitstream_t* stream, int64_t* value)
 int exi_basetypes_decoder_characters(exi_bitstream_t* stream, size_t characters_len, exi_character_t* characters, size_t characters_size)
 {
     const uint8_t ASCII_MAX_VALUE = 127;
-    int error;
 
     if (characters_len + EXTRA_CHAR > characters_size)
     {
@@ -358,6 +357,7 @@ int exi_basetypes_decoder_characters(exi_bitstream_t* stream, size_t characters_
 
     for (size_t n = 0; n < characters_len; n++)
     {
+        int error;
         error = exi_bitstream_read_octet(stream, current_char);
         if (error != EXI_ERROR__NO_ERROR)
         {

--- a/src/input/code_templates/c/static_code/exi_basetypes_encoder.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes_encoder.c.jinja
@@ -19,12 +19,11 @@ static int exi_basetypes_encoder_write_unsigned(exi_bitstream_t* stream, exi_uns
         stream->status_callback(EXI_DEBUG__BASETYPES_ENCODE_UNSIGNED, 0, exi_unsigned->octets_count, 0);
     }
 {% endif %}
-    int error;
-
     uint8_t* current_octet = exi_unsigned->octets;
 
     for (size_t n = 0; n < exi_unsigned->octets_count; n++)
     {
+        int error;
         error = exi_bitstream_write_octet(stream, *current_octet);
         if (error != EXI_ERROR__NO_ERROR)
         {
@@ -60,7 +59,7 @@ int exi_basetypes_encoder_bool(exi_bitstream_t* stream, int value)
 /*****************************************************************************
  * interface functions - bytes, binary
  *****************************************************************************/
-int exi_basetypes_encoder_bytes(exi_bitstream_t* stream, size_t bytes_len, uint8_t* bytes, size_t bytes_size)
+int exi_basetypes_encoder_bytes(exi_bitstream_t* stream, size_t bytes_len, const uint8_t* bytes, size_t bytes_size)
 {
 {%- if add_debug_code == 1 %}
     if (stream->status_callback)
@@ -68,17 +67,16 @@ int exi_basetypes_encoder_bytes(exi_bitstream_t* stream, size_t bytes_len, uint8
         stream->status_callback(EXI_DEBUG__BASETYPES_ENCODE_BYTES, 0, bytes_len, bytes_size);
     }
 {% endif %}
-    int error;
-
     if (bytes_len > bytes_size)
     {
         return EXI_ERROR__BYTE_BUFFER_TOO_SMALL;
     }
 
-    uint8_t* current_byte = bytes;
+    uint8_t* current_byte = (uint8_t*)bytes;
 
     for (size_t n = 0; n < bytes_len; n++)
     {
+        int error;
         error = exi_bitstream_write_octet(stream, *current_byte);
         if (error != EXI_ERROR__NO_ERROR)
         {
@@ -283,7 +281,7 @@ int exi_basetypes_encoder_integer_64(exi_bitstream_t* stream, int64_t value)
 /*****************************************************************************
  * interface functions - characters, string
  *****************************************************************************/
-int exi_basetypes_encoder_characters(exi_bitstream_t* stream, size_t characters_len, exi_character_t* characters, size_t characters_size)
+int exi_basetypes_encoder_characters(exi_bitstream_t* stream, size_t characters_len, const exi_character_t* characters, size_t characters_size)
 {
 {%- if add_debug_code == 1 %}
     if (stream->status_callback)
@@ -292,7 +290,6 @@ int exi_basetypes_encoder_characters(exi_bitstream_t* stream, size_t characters_
     }
 {% endif %}
     const uint8_t ASCII_MAX_VALUE = 127;
-    int error;
 
     if (characters_len > characters_size)
     {
@@ -303,6 +300,7 @@ int exi_basetypes_encoder_characters(exi_bitstream_t* stream, size_t characters_
 
     for (size_t n = 0; n < characters_len; n++)
     {
+        int error;
         if (*current_char > ASCII_MAX_VALUE)
         {
             return EXI_ERROR__UNSUPPORTED_CHARACTER_VALUE;

--- a/src/input/code_templates/c/static_code/exi_basetypes_encoder.h.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes_encoder.h.jinja
@@ -31,7 +31,7 @@ int exi_basetypes_encoder_bool(exi_bitstream_t* stream, int value);
  * \return                      NO_ERROR or error code
  *
  */
-int exi_basetypes_encoder_bytes(exi_bitstream_t* stream, size_t bytes_len, uint8_t* bytes, size_t bytes_size);
+int exi_basetypes_encoder_bytes(exi_bitstream_t* stream, size_t bytes_len, const uint8_t* bytes, size_t bytes_size);
 
 /**
  * \brief       encoder for n-bit unsigned integer
@@ -92,5 +92,5 @@ int exi_basetypes_encoder_integer_64(exi_bitstream_t* stream, int64_t value);
  * \return                      NO_ERROR or error code
  *
  */
-int exi_basetypes_encoder_characters(exi_bitstream_t* stream, size_t characters_len, exi_character_t* characters, size_t characters_size);
+int exi_basetypes_encoder_characters(exi_bitstream_t* stream, size_t characters_len, const exi_character_t* characters, size_t characters_size);
 {% endblock %}

--- a/src/input/code_templates/c/static_code/exi_bitstream.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_bitstream.c.jinja
@@ -137,7 +137,7 @@ void exi_bitstream_reset(exi_bitstream_t* stream)
 {%- endif %}
 }
 
-size_t exi_bitstream_get_length(exi_bitstream_t* stream)
+size_t exi_bitstream_get_length(const exi_bitstream_t* stream)
 {
     size_t length = stream->byte_pos;
 
@@ -165,11 +165,11 @@ int exi_bitstream_write_bits(exi_bitstream_t* stream, size_t bit_count, uint32_t
         return EXI_ERROR__BIT_COUNT_LARGER_THAN_TYPE_SIZE;
     }
 
-    uint8_t bit;
     int error = EXI_ERROR__NO_ERROR;
 
     for (size_t n = 0; n < bit_count; n++)
     {
+        uint8_t bit;
         bit = (value & (1u << (bit_count - n - 1))) > 0;
 
         error = exi_bitstream_write_bit(stream, bit);
@@ -196,11 +196,11 @@ int exi_bitstream_read_bits(exi_bitstream_t* stream, size_t bit_count, uint32_t*
         return EXI_ERROR__BIT_COUNT_LARGER_THAN_TYPE_SIZE;
     }
 
-    uint8_t bit;
     int error = EXI_ERROR__NO_ERROR;
 
     for (size_t n = 0; n < bit_count; n++)
     {
+        uint8_t bit;
         error = exi_bitstream_read_bit(stream, &bit);
         if (error != EXI_ERROR__NO_ERROR)
         {
@@ -223,11 +223,11 @@ int exi_bitstream_read_octet(exi_bitstream_t* stream, uint8_t* value)
 {
     *value = 0;
 
-    uint8_t bit;
     int error = EXI_ERROR__NO_ERROR;
 
     for (int n = 0; n < 8; n++)
     {
+        uint8_t bit;
         error = exi_bitstream_read_bit(stream, &bit);
         if (error != EXI_ERROR__NO_ERROR)
         {

--- a/src/input/code_templates/c/static_code/exi_bitstream.h.jinja
+++ b/src/input/code_templates/c/static_code/exi_bitstream.h.jinja
@@ -103,7 +103,7 @@ void exi_bitstream_reset(exi_bitstream_t* stream);
  * \return                  length of stream
  *
  */
-size_t exi_bitstream_get_length(exi_bitstream_t* stream);
+size_t exi_bitstream_get_length(const exi_bitstream_t* stream);
 
 /**
  * \brief       bitstream write bits

--- a/src/input/code_templates/c/static_code/exi_v2gtp.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_v2gtp.c.jinja
@@ -32,12 +32,12 @@ void V2GTP20_WriteHeader(uint8_t* stream_data, uint32_t stream_payload_length, u
     stream_data[7] = (uint8_t)(stream_payload_length & 0xFFu);
 }
 
-int V2GTP_ReadHeader(uint8_t* stream_data, uint32_t* stream_payload_length)
+int V2GTP_ReadHeader(const uint8_t* stream_data, uint32_t* stream_payload_length)
 {
     return V2GTP20_ReadHeader(stream_data, stream_payload_length, V2GTP20_SAP_PAYLOAD_ID);
 }
 
-int V2GTP20_ReadHeader(uint8_t* stream_data, uint32_t* stream_payload_length, uint16_t v2gtp20_payload_id)
+int V2GTP20_ReadHeader(const uint8_t* stream_data, uint32_t* stream_payload_length, uint16_t v2gtp20_payload_id)
 {
     uint16_t payload_id;
 

--- a/src/input/code_templates/c/static_code/exi_v2gtp.h.jinja
+++ b/src/input/code_templates/c/static_code/exi_v2gtp.h.jinja
@@ -54,6 +54,6 @@ void V2GTP20_WriteHeader(uint8_t* stream_data, uint32_t stream_payload_length, u
  * @retval  on success V2GTP_ERROR__NO_ERROR otherwise an error code
  *
  */
-int V2GTP_ReadHeader(uint8_t* stream_data, uint32_t* stream_payload_length);
-int V2GTP20_ReadHeader(uint8_t* stream_data, uint32_t* stream_payload_length, uint16_t v2gtp20_payload_id);
+int V2GTP_ReadHeader(const uint8_t* stream_data, uint32_t* stream_payload_length);
+int V2GTP20_ReadHeader(const uint8_t* stream_data, uint32_t* stream_payload_length, uint16_t v2gtp20_payload_id);
 {% endblock %}


### PR DESCRIPTION
Some function parameters are now declared as const.
The scope of some variables was reduced.