### PR TITLE
low-level EXI codec: fix left-shift for large integers

### DIFF
--- a/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
@@ -70,7 +70,7 @@ int exi_basetypes_convert_from_unsigned(exi_unsigned_t* exi_unsigned, uint32_t* 
 
     for (size_t n = 0; n < exi_unsigned->octets_count; n++)
     {
-        *value = (uint32_t)(*value + ((*current_octet & EXI_BASETYPES_OCTET_SEQ_VALUE_MASK) << (n * 7)));
+        *value = *value + ((uint32_t)(*current_octet & EXI_BASETYPES_OCTET_SEQ_VALUE_MASK) << (n * 7));
 
         current_octet++;
     }
@@ -90,7 +90,7 @@ int exi_basetypes_convert_64_from_unsigned(exi_unsigned_t* exi_unsigned, uint64_
 
     for (size_t n = 0; n < exi_unsigned->octets_count; n++)
     {
-        *value = (uint64_t)(*value + ((*current_octet & EXI_BASETYPES_OCTET_SEQ_VALUE_MASK) << (n * 7)));
+        *value = *value + ((uint64_t)(*current_octet & EXI_BASETYPES_OCTET_SEQ_VALUE_MASK) << (n * 7));
 
         current_octet++;
     }


### PR DESCRIPTION
The left-hand side of a left-shift operation only gets promoted up to "int", if too small to support the number of bits created. This leads to truncation in case of resulting values with more than 32 significant bits, which are expected in a 64-bit value decoder.

Move the typecast to the left-shifted variable. Do the same for the 32-bit case, for consistency.

Fixes https://github.com/EVerest/cbexigen/issues/49