### PR TITLE
Fix missing fragment end marker and missing elements

### DIFF
--- a/src/cbexigen/SchemaAnalyzer.py
+++ b/src/cbexigen/SchemaAnalyzer.py
@@ -1074,11 +1074,7 @@ class SchemaAnalyzer(object):
         for component in self.__current_schema.iter_components():
             if isinstance(component, Xsd11Element):
                 if component.name not in fragments.keys():
-                    fragment = __get_fragment(component)
-                    if len(ambiguous_names_list) > 0:
-                        if fragment.name in ambiguous_names_list:
-                            fragment.type = ambiguous_names_list[fragment.name]
-                    fragments[component.name] = fragment
+                    fragments[component.name] = __get_fragment(component)
 
         for import_item in self.__current_schema.imports.values():
             imported_schema = XMLSchema11(import_item.name, base_url=self.__schema_base, build=True)

--- a/src/cbexigen/decoder_classes.py
+++ b/src/cbexigen/decoder_classes.py
@@ -814,6 +814,17 @@ class ExiDecoderCode(ExiBaseCoderCode):
     def __get_fragment_content(self):
         content = ''
         comment = '// main function for decoding fragment'
+        if not self.__is_iso20:
+            comment += ('\n/* NOTE! There may be problems when comparing the signature of the eMAID.\n'
+                        '   In the ISO 15118-2 schema there are two different types with problematic names,\n'
+                        '   EMAIDType and eMAIDType. The fragment de- and encoder of e.g. openV2G considers\n'
+                        '   this type as generic type EXISchemaInformedElementFragmentGrammar. '
+                        'We treat it as a complex type.\n'
+                        '   We have not yet been able to determine why this particular type has to be coded as '
+                        'a generic type,\n   and only for the fragment decoder and encoder.\n'
+                        '   This is why we have not yet adapted our fragment coders, '
+                        'and it can lead to the problem mentioned. */')
+
         fn_name = (f'{CONFIG_PARAMS["decode_function_prefix"]}{self.__schema_prefix}'
                    f'{CONFIG_PARAMS["fragment_struct_name"]}')
         struct_type = f'{self.__schema_prefix}{CONFIG_PARAMS["fragment_struct_name"]}'
@@ -831,6 +842,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
                 decode_fn.append([fragment.name, fragment.namespace, '', ''])
 
         decode_fn.sort()
+        end_fragment = len(decode_fn) + 1
         bits = tools.get_bits_to_decode(len(self.analyzer_data.known_fragments))
 
         temp = self.generator.get_template('DecodeFragmentFunction.jinja')
@@ -840,6 +852,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
                                init_function=init_fn,
                                bits_to_read=bits,
                                decode_functions=decode_fn,
+                               end_fragment=end_fragment,
                                indent=self.indent)
         content += '\n'
 
@@ -866,6 +879,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
                     decode_fn.append([fragment.name, fragment.namespace, '', ''])
 
         decode_fn.sort()
+        end_fragment = len(decode_fn) + 1
         bits = tools.get_bits_to_decode(len(decode_fn))
 
         temp = self.generator.get_template('DecodeFragmentFunction.jinja')
@@ -875,6 +889,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
                                init_function=init_fn,
                                bits_to_read=bits,
                                decode_functions=decode_fn,
+                               end_fragment=end_fragment,
                                indent=self.indent)
         content += '\n'
 

--- a/src/cbexigen/encoder_classes.py
+++ b/src/cbexigen/encoder_classes.py
@@ -834,6 +834,17 @@ class ExiEncoderCode(ExiBaseCoderCode):
     def __get_fragment_content(self):
         content = ''
         comment = '// main function for encoding fragment'
+        if not self.__is_iso20:
+            comment += ('\n/* NOTE! There may be problems when comparing the signature of the eMAID.\n'
+                        '   In the ISO 15118-2 schema there are two different types with problematic names,\n'
+                        '   EMAIDType and eMAIDType. The fragment de- and encoder of e.g. openV2G considers\n'
+                        '   this type as generic type EXISchemaInformedElementFragmentGrammar. '
+                        'We treat it as a complex type.\n'
+                        '   We have not yet been able to determine why this particular type has to be coded as '
+                        'a generic type,\n   and only for the fragment decoder and encoder.\n'
+                        '   This is why we have not yet adapted our fragment coders, '
+                        'and it can lead to the problem mentioned. */')
+
         fn_name = (f'{CONFIG_PARAMS["encode_function_prefix"]}{self.__schema_prefix}'
                    f'{CONFIG_PARAMS["fragment_struct_name"]}')
         struct_type = f'{self.__schema_prefix}{CONFIG_PARAMS["fragment_struct_name"]}'
@@ -849,6 +860,7 @@ class ExiEncoderCode(ExiBaseCoderCode):
                 encode_fn.append([fragment.name, fragment.namespace, '', ''])
 
         encode_fn.sort()
+        end_fragment = len(encode_fn) + 1
         bits = tools.get_bits_to_decode(len(self.analyzer_data.known_fragments))
 
         temp = self.generator.get_template('EncodeFragmentFunction.jinja')
@@ -857,6 +869,7 @@ class ExiEncoderCode(ExiBaseCoderCode):
                                struct_type=struct_type, parameter_name=parameter_name,
                                bits_to_encode=bits,
                                encode_functions=encode_fn,
+                               end_fragment=end_fragment,
                                indent=self.indent)
         content += '\n'
 
@@ -881,6 +894,7 @@ class ExiEncoderCode(ExiBaseCoderCode):
                     encode_fn.append([fragment.name, fragment.namespace, '', ''])
 
         encode_fn.sort()
+        end_fragment = len(encode_fn) + 1
         bits = tools.get_bits_to_decode(len(encode_fn))
 
         temp = self.generator.get_template('EncodeFragmentFunction.jinja')
@@ -889,6 +903,7 @@ class ExiEncoderCode(ExiBaseCoderCode):
                                struct_type=struct_type, parameter_name=parameter_name,
                                bits_to_encode=bits,
                                encode_functions=encode_fn,
+                               end_fragment=end_fragment,
                                indent=self.indent)
         content += '\n'
 

--- a/src/config.py
+++ b/src/config.py
@@ -41,6 +41,14 @@ encode_function_prefix = 'encode_'
 decode_function_prefix = 'decode_'
 choice_sequence_prefix = 'choice_'
 
+# Ambiguous element names are elements with the same name but different types.
+# Currently, this only seems to apply to the eMAID element from ISO 15118-2.
+# With the fragment coder, the type for the ambiguous element must be specified
+# here so that the correct decoder or encoder is called.
+iso2_ambiguous_element_names = {
+    'eMAID': 'EMAIDType',
+}
+
 # optimizations for arrays and structs
 apply_optimizations = 1
 # the name of this parameter must consist of the schema prefix (chosen below)
@@ -70,6 +78,13 @@ iso20_array_optimizations = {
 
 # if fragment de- and encoder should be generated, set this value to 1.
 # Currently only complex elements can be added to the fragment coders.
+# NOTE! There may be problems when comparing the signature of the eMAID.
+#       In the ISO 15118-2 schema there are two different types with problematic names, EMAIDType and eMAIDType.
+#       The fragment de- and encoder of e.g. openV2G considers this type as generic type
+#       EXISchemaInformedElementFragmentGrammar. We treat it as a complex type.
+#       We have not yet been able to determine why this particular type has to be coded as a generic type,
+#       and only for the fragment decoder and encoder.
+#       This is why we have not yet adapted our fragment coders, and it can lead to the problem mentioned.
 generate_fragments = 1
 # fragment structure definitions
 fragment_struct_name = 'exiFragment'
@@ -81,18 +96,21 @@ iso2_fragments = [
     'SignedInfo',
     'AuthorizationReq',
     'CertificateInstallationReq',
-    'CertificateInstallationRes',
     'CertificateUpdateReq',
-    'CertificateUpdateRes',
-    'ChargeParameterDiscoveryRes',
+    'ContractSignatureCertChain',
+    'ContractSignatureEncryptedPrivateKey',
+    'DHpublickey',
     'MeteringReceiptReq',
+    'SalesTariff',
+    'eMAID',
 ]
 iso20_fragments = [
     'SignedInfo',
-    'AuthorizationReq',
+    'PnC_AReqAuthorizationMode',
     'CertificateInstallationReq',
-    'CertificateInstallationRes',
+    'SignedInstallationData',
     'MeteringConfirmationReq',
+    'AbsolutePriceSchedule',
 ]
 iso20_ac_fragments = [
     'SignedInfo',

--- a/src/input/code_templates/c/decoder/DecodeFragmentFunction.jinja
+++ b/src/input/code_templates/c/decoder/DecodeFragmentFunction.jinja
@@ -26,6 +26,19 @@ int {{ function_name }}(exi_bitstream_t* stream, struct {{ struct_type }}* {{ pa
 {{ indent * 4 }}error = EXI_ERROR__UNSUPPORTED_SUB_EVENT;
 {{ indent * 4 }}break;
 {{ indent * 3 }}}
+
+{{ indent * 3 }}if (error == EXI_ERROR__NO_ERROR)
+{{ indent * 3 }}{
+{{ indent * 4 }}// End Fragment
+{{ indent * 4 }}error = exi_basetypes_decoder_nbit_uint(stream, {{ bits_to_read }}, &eventCode);
+{{ indent * 4 }}if (error == EXI_ERROR__NO_ERROR)
+{{ indent * 4 }}{
+{{ indent * 5 }}if (eventCode != {{ end_fragment }})
+{{ indent * 5 }}{
+{{ indent * 6 }}error = EXI_ERROR__INCORRECT_END_FRAGMENT_VALUE;
+{{ indent * 5 }}}
+{{ indent * 4 }}}
+{{ indent * 3 }}}
 {{ indent * 2 }}}
 {{ indent }}}
 

--- a/src/input/code_templates/c/encoder/EncodeFragmentFunction.jinja
+++ b/src/input/code_templates/c/encoder/EncodeFragmentFunction.jinja
@@ -44,6 +44,12 @@ int {{ function_name }}(exi_bitstream_t* stream, struct {{ struct_type }}* {{ pa
 {{ indent * 2 }}{
 {{ indent * 3 }}error = EXI_ERROR__UNKNOWN_EVENT_FOR_ENCODING;
 {{ indent * 2 }}}
+
+{{ indent * 2 }}if (error == EXI_ERROR__NO_ERROR)
+{{ indent * 2 }}{
+{{ indent * 3 }}// End Fragment
+{{ indent * 3 }}error = exi_basetypes_encoder_nbit_uint(stream, {{ bits_to_encode }}, {{ end_fragment }});
+{{ indent * 2 }}}
 {{ indent }}}
 
 {{ indent }}return error;

--- a/src/input/code_templates/c/static_code/exi_error_codes.h.jinja
+++ b/src/input/code_templates/c/static_code/exi_error_codes.h.jinja
@@ -48,6 +48,9 @@
 #define EXI_ERROR__UNSUPPORTED_DATETIME_TYPE -211
 #define EXI_ERROR__UNSUPPORTED_CHARACTER_VALUE -212
 
+//      fragment errors -230 to -259
+#define EXI_ERROR__INCORRECT_END_FRAGMENT_VALUE -230
+
 //      internal errors
 #define EXI_ERROR__NOT_IMPLEMENTED_YET -299
 {% endblock %}


### PR DESCRIPTION
Some elements could not be signed - added.
Element `eMAID` is ambiguous, so applied a selection hack to choose the correct type.
No fragment end marker was being produced or checked - added.
The enumeration of fragment event codes was missing some elements - fixed.

Fixes https://github.com/EVerest/cbexigen/issues/53
Fixes https://github.com/EVerest/cbexigen/issues/57
