### PR TITLE
use parentheses in macros

### DIFF
--- a/src/input/code_templates/c/BaseDefines.jinja
+++ b/src/input/code_templates/c/BaseDefines.jinja
@@ -1,3 +1,3 @@
 {%- for key, value in defines.items() %}
-#define {{ key }} {{ value }}
+#define {{ key }} ({{ value }})
 {%- endfor %}


### PR DESCRIPTION
It's always safer to use brackets for expressions within macros.

While all internal uses of these macros without brackets are safe, with this change we open the macros for better use with the API.

Fixes https://github.com/EVerest/cbexigen/issues/61

Reported-by: https://github.com/kwoyhope