### PR TITLE
Updated xmlschema to version 3.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-xmlschema[codegen]==1.11.3
+xmlschema[codegen]~=3.0.2


### PR DESCRIPTION
## Describe your changes

There seems to be a problem with the Python package `xmlschema` version 1.11.3 and Python 3.12.
So updating `xmlschema` to 3.0.2 in `requirements.txt` solve the problem.

## Issue ticket number and link

#59 Update xmlschema to the latest version to support Python 3.12

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

