### PR TITLE
config: increase size of ParameterType

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -72,8 +72,8 @@ iso20_array_optimizations = {
     # reason to restrict this currently
     'PriceRuleStackType': 64,
     # Workaround for missing loop implementation of large arrays (https://github.com/EVerest/cbexigen/issues/28).
-    'ParameterSetType': 5,
-    'ParameterType': 5,
+    'ParameterSetType': 4,
+    'ParameterType': 8
 }
 
 # if fragment de- and encoder should be generated, set this value to 1.


### PR DESCRIPTION
## Describe your changes
A size of five proved impractical for real-world use cases. Increase to eight.

ParameterSet is reduced from five to four.

## Issue ticket number and link

https://github.com/EVerest/cbexigen/issues/72

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

