### PR TITLE
Fix compiler warnings in generated c code.

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -307,7 +307,8 @@ c_files_to_generate = {
             'identifier': 'APP_HANDSHAKE_DECODER_C',
             'include_std_lib': ['stdint.h'],
             'include_other': ['exi_basetypes.h', 'exi_basetypes_decoder.h', 'exi_error_codes.h',
-                              'exi_header.h', 'exi_types_decoder.h', 'appHand_Datatypes.h']
+                              'exi_header.h', 'exi_types_decoder.h', 'appHand_Datatypes.h',
+                              'appHand_Decoder.h']
         }
     },
     'appHand_Encoder': {
@@ -326,7 +327,7 @@ c_files_to_generate = {
             'identifier': 'APP_HANDSHAKE_ENCODER_C',
             'include_std_lib': ['stdint.h'],
             'include_other': ['exi_basetypes_encoder.h', 'exi_error_codes.h',
-                              'exi_header.h', 'appHand_Datatypes.h']
+                              'exi_header.h', 'appHand_Datatypes.h', 'appHand_Encoder.h']
         }
     },
     'din_msgDefDatatypes': {

--- a/src/input/code_templates/c/static_code/exi_basetypes_encoder.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes_encoder.c.jinja
@@ -72,7 +72,7 @@ int exi_basetypes_encoder_bytes(exi_bitstream_t* stream, size_t bytes_len, const
         return EXI_ERROR__BYTE_BUFFER_TOO_SMALL;
     }
 
-    uint8_t* current_byte = (uint8_t*)bytes;
+    const uint8_t* current_byte = bytes;
 
     for (size_t n = 0; n < bytes_len; n++)
     {
@@ -296,7 +296,7 @@ int exi_basetypes_encoder_characters(exi_bitstream_t* stream, size_t characters_
         return EXI_ERROR__CHARACTER_BUFFER_TOO_SMALL;
     }
 
-    uint8_t* current_char = (uint8_t*)characters;
+    const uint8_t* current_char = (const uint8_t*)characters;
 
     for (size_t n = 0; n < characters_len; n++)
     {

--- a/src/input/code_templates/c/static_code/exi_bitstream.h.jinja
+++ b/src/input/code_templates/c/static_code/exi_bitstream.h.jinja
@@ -52,7 +52,7 @@
 
 typedef void (*exi_status_callback)(int message_id, int status_code, int value_1, int value_2);
 
-typedef struct {
+typedef struct exi_bitstream {
     /* byte array size and data */
     uint8_t* data;
     size_t data_size;


### PR DESCRIPTION
## Describe your changes
- Fixed const cast compiler warnings in generated C code
- exi_basetypes_encoder.c const cast warnings
- appHand_Decoder.c and appHandEncoder.c missing header file includes (function with no prototype warning)
- exi_bitstream.h added struct name to exibitstream_t type so can be used in c++
## Issue ticket number and link
https://github.com/EVerest/libcbv2g/pull/16#pullrequestreview-2308669100

## Checklist before requesting a review

- [Y ] I have performed a self-review of my code
- [ -] I have made corresponding changes to the documentation
- [ Y] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

