### PR TITLE
Represent big integers as arrays of bytes

### DIFF
--- a/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
@@ -155,7 +155,7 @@ int exi_basetypes_convert_bytes_from_unsigned(const exi_unsigned_t* exi_unsigned
         }
         current_octet++;
     }
-    if (total_offset != 0) {
+    if (total_offset != 0 && (temp & 0xFF) != 0) {
         if (*data_len >= data_size) {
             return EXI_ERROR__ENCODED_INTEGER_SIZE_LARGER_THAN_DESTINATION;
         }
@@ -187,7 +187,7 @@ int exi_basetypes_convert_bytes_to_unsigned(exi_unsigned_t* exi_unsigned, const 
 
         *current_octet |= EXI_BASETYPES_OCTET_SEQ_FLAG_MASK;
     }
-    if (dummy_count > 0) {
+    if (dummy_count > 0 && dummy != 0) {
         *(current_octet - 1) |= EXI_BASETYPES_OCTET_SEQ_FLAG_MASK;
         exi_unsigned->octets_count++;
         *current_octet = (uint8_t)(dummy & EXI_BASETYPES_OCTET_SEQ_VALUE_MASK);

--- a/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
@@ -180,6 +180,7 @@ int exi_basetypes_convert_bytes_from_unsigned(const exi_unsigned_t* exi_unsigned
         data[*data_len] = temp & 0xFF;
         (*data_len)++;
     }
+    _reverse_array(data, *data_len);
     return EXI_ERROR__NO_ERROR;
 }
 
@@ -189,9 +190,9 @@ int exi_basetypes_convert_bytes_to_unsigned(exi_unsigned_t* exi_unsigned, const 
     uint16_t dummy = 0;
     uint8_t dummy_count = 0;
 
-    for (size_t n = 0; n != data_len; n++, current_octet++) {
+    for (size_t n = 0; n < data_len; n++, current_octet++) {
         if (dummy_count <= 8) {
-            dummy |= (data[n] << dummy_count);
+            dummy |= (data[data_len - n - 1] << dummy_count);
             dummy_count += 8;
         }
         exi_unsigned->octets_count++;

--- a/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
@@ -154,6 +154,7 @@ static void _reverse_array(uint8_t* data, size_t data_size)
 
 int exi_basetypes_convert_bytes_from_unsigned(const exi_unsigned_t* exi_unsigned, uint8_t* data, size_t* data_len, size_t data_size)
 {
+    // raw EXI 7/8 integer byte stream with flags (exi_unsigned) to API exi_unsigned_t representation (data, data_len)
     const uint8_t* current_octet = exi_unsigned->octets;
     uint16_t temp = 0;
     *data_len = 0;
@@ -186,6 +187,7 @@ int exi_basetypes_convert_bytes_from_unsigned(const exi_unsigned_t* exi_unsigned
 
 int exi_basetypes_convert_bytes_to_unsigned(exi_unsigned_t* exi_unsigned, const uint8_t* data, size_t data_len)
 {
+    // API exi_unsigned_t representation (data, data_len) to raw EXI 7/8 integer byte stream with flags (exi_unsigned)
     uint8_t *current_octet = &exi_unsigned->octets[0];
     uint16_t dummy = 0;
     uint8_t dummy_count = 0;

--- a/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
@@ -192,6 +192,10 @@ int exi_basetypes_convert_bytes_to_unsigned(exi_unsigned_t* exi_unsigned, const 
     uint16_t dummy = 0;
     uint8_t dummy_count = 0;
 
+    // FIXME: this should loop every seven output bits, not every eight
+    //        input bits
+    // FIXME: this should omit EXI_BASETYPES_OCTET_SEQ_FLAG_MASK when the
+    //        last (7) bits have been streamed
     for (size_t n = 0; n < data_len; n++, current_octet++) {
         if (dummy_count <= 8) {
             dummy |= (data[data_len - n - 1] << dummy_count);

--- a/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
@@ -134,6 +134,24 @@ int exi_basetypes_convert_64_from_signed(const exi_signed_t* exi_signed, int64_t
     return res;
 }
 
+static void _reverse_array(uint8_t* data, size_t data_size)
+{
+    if (!data || !data_size)
+    {
+        return;
+    }
+
+    size_t i = 0;
+    size_t j = data_size - 1;
+    while (i < j) {
+        const uint8_t temp = data[i];
+        data[i] = data[j];
+        data[j] = temp;
+        i++;
+        j--;
+    }
+}
+
 int exi_basetypes_convert_bytes_from_unsigned(const exi_unsigned_t* exi_unsigned, uint8_t* data, size_t* data_len, size_t data_size)
 {
     const uint8_t* current_octet = exi_unsigned->octets;

--- a/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
@@ -21,7 +21,7 @@ int exi_basetypes_convert_to_unsigned(exi_unsigned_t* exi_unsigned, uint32_t val
         exi_unsigned->octets_count++;
         *current_octet = (uint8_t)(dummy & EXI_BASETYPES_OCTET_SEQ_VALUE_MASK);
 
-        dummy = dummy >> 7u;
+        dummy >>= 7u;
         if (dummy == 0)
         {
             break;
@@ -45,7 +45,7 @@ int exi_basetypes_convert_64_to_unsigned(exi_unsigned_t* exi_unsigned, uint64_t 
         exi_unsigned->octets_count++;
         *current_octet = (uint8_t)(dummy & EXI_BASETYPES_OCTET_SEQ_VALUE_MASK);
 
-        dummy = dummy >> 7u;
+        dummy >>= 7u;
         if (dummy == 0)
         {
             break;
@@ -186,7 +186,7 @@ int exi_basetypes_convert_bytes_to_unsigned(exi_unsigned_t* exi_unsigned, const 
         *current_octet |= EXI_BASETYPES_OCTET_SEQ_FLAG_MASK;
     }
     if (dummy_count > 0) {
-        *(current_octet-1) |= EXI_BASETYPES_OCTET_SEQ_FLAG_MASK;
+        *(current_octet - 1) |= EXI_BASETYPES_OCTET_SEQ_FLAG_MASK;
         exi_unsigned->octets_count++;
         *current_octet = (uint8_t)(dummy & EXI_BASETYPES_OCTET_SEQ_VALUE_MASK);
     }

--- a/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
@@ -178,14 +178,10 @@ int exi_basetypes_convert_bytes_to_unsigned(exi_unsigned_t* exi_unsigned, const 
         }
         exi_unsigned->octets_count++;
         *current_octet = (uint8_t)(dummy & EXI_BASETYPES_OCTET_SEQ_VALUE_MASK);
+        *current_octet |= EXI_BASETYPES_OCTET_SEQ_FLAG_MASK;
 
         dummy >>= 7u;
         dummy_count -= 7;
-        if (n == data_len) {
-            break;
-        }
-
-        *current_octet |= EXI_BASETYPES_OCTET_SEQ_FLAG_MASK;
     }
     if (dummy_count > 0 && dummy != 0) {
         *(current_octet - 1) |= EXI_BASETYPES_OCTET_SEQ_FLAG_MASK;

--- a/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
@@ -193,27 +193,50 @@ int exi_basetypes_convert_bytes_to_unsigned(exi_unsigned_t* exi_unsigned, const 
     uint8_t dummy_count = 0;
     exi_unsigned->octets_count = 0;
 
-    // FIXME: this should loop every seven output bits, not every eight
-    //        input bits
-    // FIXME: this should omit EXI_BASETYPES_OCTET_SEQ_FLAG_MASK when the
-    //        last (7) bits have been streamed
-    for (size_t n = 0; n < data_len; n++, current_octet++) {
-        if (dummy_count <= 8) {
-            dummy |= (data[data_len - n - 1] << dummy_count);
-            dummy_count += 8;
-        }
-        exi_unsigned->octets_count++;
-        *current_octet = (uint8_t)(dummy & EXI_BASETYPES_OCTET_SEQ_VALUE_MASK);
-        *current_octet |= EXI_BASETYPES_OCTET_SEQ_FLAG_MASK;
+    // first, determine the number of relevant bits (or octets), to have a termination criterion
+    size_t bytenum;
+    for (bytenum = 0; bytenum < data_len; bytenum++) {
+        if (data[bytenum] != 0)
+            break;
+    }
+    if (bytenum == data_len) {
+        // special case: all zeros
+        *current_octet = 0;
+        exi_unsigned->octets_count = 1;
+        return EXI_ERROR__NO_ERROR;
+    }
+    // bytenum is now index of big-endian first relevant byte
+    // number of total input relevant bits t is (data_len - bytenum - 1) * 8 plus number of relevant bits in data[bytenum]
+    uint8_t byte = data[bytenum];
+    int bits_in_byte = 0;
+    while (byte) {
+        bits_in_byte++;
+        byte >>= 1;
+    }
 
+    const int total_relevant_input_bits = (data_len - bytenum - 1) * 8 + bits_in_byte;
+    const size_t exi_expected_octets_count = (total_relevant_input_bits + 6) / 7; // integer division ceil
+
+    size_t incount = 0;
+    for (size_t outcount = 0; outcount < exi_expected_octets_count; outcount++) {
+        if (dummy_count < 7) {
+            // fill dummy when more flushable bits are needed
+            dummy |= (data[data_len - incount - 1] << dummy_count);
+            dummy_count += 8;
+            incount++;
+        }
+        *current_octet = (uint8_t)(dummy & EXI_BASETYPES_OCTET_SEQ_VALUE_MASK);
+        exi_unsigned->octets_count++;
+        if (exi_unsigned->octets_count < exi_expected_octets_count) {
+            *current_octet |= EXI_BASETYPES_OCTET_SEQ_FLAG_MASK;
+        } else {
+            break;
+        }
+        current_octet++;
         dummy >>= 7u;
         dummy_count -= 7;
     }
-    if (dummy_count > 0 && dummy != 0) {
-        *(current_octet - 1) |= EXI_BASETYPES_OCTET_SEQ_FLAG_MASK;
-        exi_unsigned->octets_count++;
-        *current_octet = (uint8_t)(dummy & EXI_BASETYPES_OCTET_SEQ_VALUE_MASK);
-    }
+
     return EXI_ERROR__NO_ERROR;
 }
 

--- a/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
@@ -136,7 +136,7 @@ int exi_basetypes_convert_64_from_signed(const exi_signed_t* exi_signed, int64_t
 
 static void _reverse_array(uint8_t* data, size_t data_size)
 {
-    if (!data || !data_size)
+    if (!data_size)
     {
         return;
     }

--- a/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
@@ -145,20 +145,22 @@ int exi_basetypes_convert_bytes_from_unsigned(const exi_unsigned_t* exi_unsigned
         temp += ((uint16_t)(*current_octet & EXI_BASETYPES_OCTET_SEQ_VALUE_MASK) << total_offset);
         total_offset += 7;
         if (total_offset >= 8) {
-            if (data_size == *data_len) {
+            if (*data_len >= data_size) {
                 return EXI_ERROR__ENCODED_INTEGER_SIZE_LARGER_THAN_DESTINATION;
             }
             total_offset -= 8;
-            data[(*data_len)++] = temp & 0xFF;
+            data[*data_len] = temp & 0xFF;
+            (*data_len)++;
             temp >>= 8;
         }
         current_octet++;
     }
     if (total_offset != 0) {
-        if (data_size == *data_len) {
+        if (*data_len >= data_size) {
             return EXI_ERROR__ENCODED_INTEGER_SIZE_LARGER_THAN_DESTINATION;
         }
-        data[(*data_len)++] = temp & 0xFF;
+        data[*data_len] = temp & 0xFF;
+        (*data_len)++;
     }
     return EXI_ERROR__NO_ERROR;
 }

--- a/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes.c.jinja
@@ -191,6 +191,7 @@ int exi_basetypes_convert_bytes_to_unsigned(exi_unsigned_t* exi_unsigned, const 
     uint8_t *current_octet = &exi_unsigned->octets[0];
     uint16_t dummy = 0;
     uint8_t dummy_count = 0;
+    exi_unsigned->octets_count = 0;
 
     // FIXME: this should loop every seven output bits, not every eight
     //        input bits

--- a/src/input/code_templates/c/static_code/exi_basetypes.h.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes.h.jinja
@@ -16,6 +16,8 @@
 #define EXI_STRING_MAX_LEN 64
 #define EXI_BYTE_ARRAY_MAX_LEN 350
 
+// To support EXI integer 8/7 coding, this needs to be 8/7 of the desired
+// size of 25 for EXI representation
 #define EXI_BASETYPES_MAX_OCTETS_SUPPORTED 29
 
 #define EXI_BASETYPES_OCTET_SEQ_FLAG_MASK 0x80

--- a/src/input/code_templates/c/static_code/exi_basetypes_decoder.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes_decoder.c.jinja
@@ -357,7 +357,13 @@ int exi_basetypes_decoder_signed(exi_bitstream_t* stream, exi_signed_t* value)
     }
     value->is_negative = (sign == 0) ? 0 : 1;
 
-    error = exi_basetypes_decoder_unsigned(stream, &value->data);
+    exi_unsigned_t raw_value;
+    error = exi_basetypes_decoder_unsigned(stream, &raw_value);
+    if (error != EXI_ERROR__NO_ERROR)
+    {
+        return error;
+    }
+    error = exi_basetypes_convert_bytes_from_unsigned(&raw_value, value->data.octets, &value->data.octets_count, sizeof(raw_value.octets));
     return error;
 }
 

--- a/src/input/code_templates/c/static_code/exi_basetypes_encoder.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes_encoder.c.jinja
@@ -175,7 +175,16 @@ int exi_basetypes_encoder_uint_64(exi_bitstream_t* stream, uint64_t value)
 
 int exi_basetypes_encoder_unsigned(exi_bitstream_t* stream, const exi_unsigned_t* value)
 {
-    return exi_basetypes_encoder_write_unsigned(stream, value);
+    int error;
+    exi_unsigned_t raw_exi_unsigned;
+
+    error = exi_basetypes_convert_bytes_from_unsigned(value, raw_exi_unsigned.octets, &raw_exi_unsigned.octets_count, sizeof(value->octets));
+    if (error != EXI_ERROR__NO_ERROR)
+    {
+        return error;
+    }
+
+    return exi_basetypes_encoder_write_unsigned(stream, &raw_exi_unsigned);
 }
 
 /*****************************************************************************

--- a/src/input/code_templates/c/static_code/exi_basetypes_encoder.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_basetypes_encoder.c.jinja
@@ -178,7 +178,8 @@ int exi_basetypes_encoder_unsigned(exi_bitstream_t* stream, const exi_unsigned_t
     int error;
     exi_unsigned_t raw_exi_unsigned;
 
-    error = exi_basetypes_convert_bytes_from_unsigned(value, raw_exi_unsigned.octets, &raw_exi_unsigned.octets_count, sizeof(value->octets));
+    // convert integer API bytes to EXI coded 7/8 byte stream
+    error = exi_basetypes_convert_bytes_to_unsigned(&raw_exi_unsigned, value->octets, value->octets_count);
     if (error != EXI_ERROR__NO_ERROR)
     {
         return error;


### PR DESCRIPTION
## Describe your changes
In PR https://github.com/EVerest/cbexigen/pull/65, support for proper coding of large integer (xs:integer) was added, aiding in the proper handling of X509SerialNumber.

Yet the API presented those numbers in the same style as EXI internally, i.e. with 8/7 padding, adding an indicator MSB to each octet for understanding whether the sequence continues.

This change now expects those numbers as arrays of bytes (still within an `exi_unsigned_t`), representing the integer, without any padding. The byte order is big-endian, i.e. leading bytes in the array have the most significant meaning.
## Issue ticket number and link
Relates to issue https://github.com/EVerest/cbexigen/issues/54
Amends PR https://github.com/EVerest/cbexigen/pull/65
## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

