### PR TITLE
Fix duplicated abstract choice extensions (CLReqControlMode/CLResControlMode)

### DIFF
--- a/src/cbexigen/SchemaAnalyzer.py
+++ b/src/cbexigen/SchemaAnalyzer.py
@@ -1264,6 +1264,7 @@ class SchemaAnalyzer(object):
         parent_element.has_abstract_sequence = True
         # FIXME abstract_seq may need to inherit min/max_occurs(_old)
         parent_element.abstract_sequences.append((abstract_seq, min_occurs, max_occurs))
+        log_write(f'  Adding abstract sequence to {parent_element.name_short}: {abstract_seq}.')
 
     def __copy_particles_from_empty_content_elements(self, element: ElementData, parents):
         parent: ElementData
@@ -1494,9 +1495,27 @@ class SchemaAnalyzer(object):
                 for part in list_with_missing:
                     abstract_seq.append(part.name)
 
+                # if a containing abstract sequence already exists, expand it with the newly found missing elements
+                # else just add them as an abstract sequence
+                found_exising_abstract_sequence = False
+                for element_abstract_sequence_index, element_abstract_sequence in enumerate(element.abstract_sequences):
+                    if particle.name in element_abstract_sequence[0]:  # tuple ([abstract_choice_list], min_occurs, max_occurs)
+                        found_exising_abstract_sequence = True
+                        log_write(f'  {element.name_short} already has an abstract sequence containing {particle.name}, expanding')
+                        sequence_to_expand = element.abstract_sequences[element_abstract_sequence_index][0]
+                        sequence_to_expand.extend(abstract_seq)
+                        log_write(f'Initial sequence is {element_abstract_sequence}')
+                        sequence_to_expand = sorted(set(sequence_to_expand))
+                        element_abstract_sequence_list = list(element_abstract_sequence)
+                        element_abstract_sequence_list[0] = sequence_to_expand
+                        element.abstract_sequences[element_abstract_sequence_index] = tuple(element_abstract_sequence_list)
+                        log_write(f'New     sequence is {element.abstract_sequences[element_abstract_sequence_index]}')
+                if not found_exising_abstract_sequence:
+                    element.abstract_sequences.append((abstract_seq, 1, 1))  # tuple ([abstract_choice_list], min_occurs, max_occurs)
+                # this is now true in every case
                 element.has_abstract_sequence = True
-                element.abstract_sequences.append((abstract_seq, 1, 1))
-                log_write(f'  Add abstract sequence to {element.name_short}.')
+
+                log_write(f'  Added abstract sequence to {element.name_short}: {abstract_seq}.')
 
                 for p_index, particle in enumerate(element.particles):
                     exist = [x for x in list_with_missing if x.name == particle.name]
@@ -1507,11 +1526,14 @@ class SchemaAnalyzer(object):
                     elif first_set:
                         last = p_index
 
-                log_write('  New particle list:')
+                log_write('  Old particle list:')
+                for part in element.particles:
+                    log_write(f'      {part.name} ({part.type_short})')
                 new_list = element.particles[:first]
                 new_list.extend(list_with_missing)
                 if last > 0:
                     new_list.extend(element.particles[last:])
+                log_write('  New particle list:')
                 for part in new_list:
                     log_write(f'      {part.name} ({part.type_short})')
 

--- a/src/cbexigen/SchemaAnalyzer.py
+++ b/src/cbexigen/SchemaAnalyzer.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2022 - 2023 chargebyte GmbH
 # Copyright (c) 2022 - 2023 Contributors to EVerest
-from pathlib import Path
 from typing import Union
 
 from xmlschema import XMLSchema11, XsdElement, XsdType, XsdAttribute

--- a/src/cbexigen/SchemaAnalyzer.py
+++ b/src/cbexigen/SchemaAnalyzer.py
@@ -980,9 +980,9 @@ class SchemaAnalyzer(object):
         self.__scan_elements_for_empty_content()
         self.__scan_particles_for_empty_parent_type()
 
-        # In the 15118-20 AC and Dc schema some elements have not all possible particles.
+        # In the 15118-20 AC and DC schemas, some elements do not have all possible particles.
         # This is e.g. ChargeParameterDiscovery or ChargeLoop. There are missing the BPT elements.
-        # The BPT element are just derived and extended but not abstract.
+        # The BPT elements are just derived and extended but not abstract.
         if self.__is_iso20:
             self.__scan_for_derived_and_extended_elements()
 
@@ -1470,6 +1470,7 @@ class SchemaAnalyzer(object):
                         list_with_missing.append(particle)
                         log_write(f'    Adding abstract particle {particle.name} to missing list.')
 
+                    # get the base type, add it as particle
                     missing_element = find_base_type(particle.type_short)
                     if missing_element is not None:
                         part = self.__get_particle(missing_element)
@@ -1518,6 +1519,7 @@ class SchemaAnalyzer(object):
                 element.particles = new_list
                 log_write(f'  Replacing particle list of {element.name_short}.')
                 log_write('')
+        log_write('Done with scan for derived and extended elements')
 
     def __adjust_choice_elements(self):
         log_write('')


### PR DESCRIPTION
## Describe your changes
The code to expand abstract choices ("abstract sequences") with all extended and substituted types incorrectly added an additional grammar, instead of expanding existing ones.

This fixes that issue by checking for existing particle choices which contain the expanded particle, and replacing that choice, instead of always adding it.

This should fix encoding and decoding of ISO 15118-20 ChargeLoop messages, notably the CLReqControlMode and CLResControlMode elements.
## Issue ticket number and link
https://github.com/EVerest/cbexigen/issues/52
https://github.com/EVerest/cbexigen/issues/71

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

