### PR TITLE
Config module is imported from specific path

### DIFF
--- a/src/cbexigen/tools_config.py
+++ b/src/cbexigen/tools_config.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2022 - 2023 Contributors to EVerest
 
 """ Tools for the Exi Codegenerator config """
-import importlib
+from importlib.util import module_from_spec, spec_from_file_location
 
 from typing import Union, Dict
 from pathlib import Path
@@ -70,10 +70,13 @@ def get_config_module():
     global __CONFIG_MODULE
 
     if __CONFIG_MODULE is None:
-        config_module_name = Path(CONFIG_ARGS['config_file']).name
-        if config_module_name.endswith('.py'):
-            config_module_name = config_module_name[:-3]
-        __CONFIG_MODULE = importlib.import_module(config_module_name)
+
+        config_module = Path(CONFIG_ARGS['program_dir'], CONFIG_ARGS['config_file']).resolve()
+        config_module_name = config_module.stem
+
+        spec = spec_from_file_location(config_module_name, config_module)
+        __CONFIG_MODULE = module_from_spec(spec)
+        spec.loader.exec_module(__CONFIG_MODULE)
 
     return __CONFIG_MODULE
 


### PR DESCRIPTION
## Describe your changes

This implementation enables developers to move the config.py file to a directory other than the root (i.e., the working directory). This can be particularly useful in scenarios where multiple configuration files are defined, allowing developers to organize them within a subdirectory.

The changes are fully backward compatible, ensuring that existing setups will continue to function without modification.

For example, this allows you to store multiple configuration files inside another folder and configure one of them when the main.py script is called:
![config_in_folder](https://github.com/user-attachments/assets/a90c7488-f0ae-464e-8e32-20c114bb64d8)

I hope you find this enhancement useful!

## Issue ticket number and link

[Issue number 90](https://github.com/EVerest/cbexigen/issues/90)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

