### PR TITLE
Fix EXI header check

### DIFF
--- a/src/input/code_templates/c/static_code/exi_error_codes.h.jinja
+++ b/src/input/code_templates/c/static_code/exi_error_codes.h.jinja
@@ -9,6 +9,7 @@
 //      stream header -20 to -29
 #define EXI_ERROR__HEADER_COOKIE_NOT_SUPPORTED -20
 #define EXI_ERROR__HEADER_OPTIONS_NOT_SUPPORTED -21
+#define EXI_ERROR__HEADER_INCORRECT -22
 
 //      stream read -30 to -39
 #define EXI_ERROR__SUPPORTED_MAX_OCTETS_OVERRUN -30

--- a/src/input/code_templates/c/static_code/exi_header.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_header.c.jinja
@@ -30,13 +30,13 @@ int exi_header_read_and_check(exi_bitstream_t* stream)
         return error;
     }
 
-    if (header == '$')
-    {
-        result = EXI_ERROR__HEADER_COOKIE_NOT_SUPPORTED;
-    }
-    else if (header & 0x20)
-    {
-        result = EXI_ERROR__HEADER_OPTIONS_NOT_SUPPORTED;
+    // EXI header:
+    // - two Distinguishing Bits 0b10
+    // - one Presence Bit for EXI Options "absence of options" 0b0
+    // - EXI format version "Final version 1" 0b00000
+    // results in eight header bits 0b10000000 = 0x80
+    if (header != EXI_SIMPLE_HEADER_VALUE) {
+        result = EXI_ERROR__HEADER_INCORRECT;
     }
 
     return result;


### PR DESCRIPTION
Only 0b10000000 = 0x80 is a valid EXI header for our protocols.

## Describe your changes

The existing EXI decoder header check is replaced by a simpler, but correct check.

This introduces a new error #define and obsoletes two others.

## Issue ticket number and link

Fixes https://github.com/EVerest/cbexigen/issues/102

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

