### PR TITLE
Feature/incosistent use of type array propery across code

### DIFF
--- a/src/cbexigen/datatype_classes.py
+++ b/src/cbexigen/datatype_classes.py
@@ -192,15 +192,14 @@ class DatatypeHeader:
         # generate struct for array with length variable
         indent = ' ' * self.config['c_code_indent_chars']
         comment = self.__get_particle_comment(particle)
-        type_array = 1 if particle.max_occurs > 1 else 0
-        struct_def = particle.prefixed_define_for_array if particle.max_occurs > 1 else ''
+        struct_def = particle.prefixed_define_for_array if particle.is_array else ''
 
         temp = self.generator.get_template("SubStructCharWithUsed.jinja" if with_used else "SubStructChar.jinja")
         return temp.render(indent=indent, level=indent_level,
                            struct_name=particle.name,
                            struct_type="char",
                            type_def=particle.prefixed_define_for_base_type,
-                           type_array=type_array,
+                           type_array=particle.is_array,
                            struct_def=struct_def,
                            variable_comment=comment)
 
@@ -208,15 +207,14 @@ class DatatypeHeader:
         # generate struct for array with length variable
         indent = ' ' * self.config['c_code_indent_chars']
         comment = self.__get_particle_comment(particle)
-        type_array = 1 if particle.max_occurs > 1 else 0
-        struct_def = particle.prefixed_define_for_array if particle.max_occurs > 1 else ''
+        struct_def = particle.prefixed_define_for_array if particle.is_array else ''
 
         temp = self.generator.get_template("SubStructByteWithIsUsed.jinja" if with_used else "SubStructByte.jinja")
         return temp.render(indent=indent, level=indent_level,
                            struct_name=particle.name,
                            struct_type="uint8_t",
                            type_def=particle.prefixed_define_for_base_type,
-                           type_array=type_array,
+                           type_array=particle.is_array,
                            struct_def=struct_def,
                            variable_comment=comment)
 
@@ -282,7 +280,7 @@ class DatatypeHeader:
 
         # particle type is in list, so a separate type is generated
         if particle.type in self.analyzer_data.known_elements:
-            if particle.max_occurs > 1:
+            if particle.is_array:
                 # generate struct for array with length variable
                 if particle.is_enum:
                     content += self.__generate_enum_array_struct(particle)
@@ -333,7 +331,7 @@ class DatatypeHeader:
                 content += self.__generate_base64binary(particle, False, indent_level) + '\n'
             else:
                 # max_occurs > 1, generate array type
-                if particle.max_occurs > 1:
+                if particle.is_array:
                     content += self.__generate_array_struct(particle)
                 else:
                     content += self.__generate_variable(particle) + '\n'
@@ -837,7 +835,7 @@ class DatatypeCode:
                 for particle in element.particles:
                     # TODO: check if particle is in OCCURRENCE_LIMITS_CORRECTED,
                     #       should then result in an array definition
-                    if particle.max_occurs > 1:
+                    if particle.is_array:
                         arr.append(self.__get_type_member_array(particle))
                     elif particle.min_occurs == 0:
                         if particle.parent_has_choice_sequence:

--- a/src/cbexigen/decoder_classes.py
+++ b/src/cbexigen/decoder_classes.py
@@ -187,7 +187,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
             type_content = type_value + f'.{detail.particle.value_parameter_name}'
             type_content_len = type_value + f'.{detail.particle.length_parameter_name}'
         else:
-            if detail.particle.max_occurs > 1:
+            if detail.particle.is_array:
                 decode_comment += ' (Array)'
                 type_array_length = f'{element_typename}->{detail.particle.name}.arrayLen'
                 type_value = f'{element_typename}->{detail.particle.name}'
@@ -208,7 +208,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
                                      type_content_len=type_content_len,
                                      type_define=type_define,
                                      type_option=detail.particle.is_optional,
-                                     type_array=detail.particle.max_occurs > 1,
+                                     type_array=detail.particle.is_array,
                                      type_array_length=f'{element_typename}->{detail.particle.name}.arrayLen',
                                      type_array_define=detail.particle.prefixed_define_for_array,
                                      next_grammar_id=next_grammar_id,
@@ -393,7 +393,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
         type_simple = detail.particle.is_attribute or detail.particle.is_simple_content
         next_grammar_id = detail.next_grammar
 
-        if detail.particle.max_occurs > 1:
+        if detail.particle.is_array:
             decode_comment += ' (Array)'
             type_array_length = f'{element_typename}->{detail.particle.name}.arrayLen'
             type_length = type_value + f'.array[{type_array_length}].{detail.particle.length_parameter_name}'
@@ -407,7 +407,7 @@ class ExiDecoderCode(ExiBaseCoderCode):
                                      type_chars_size=type_chars_size,
                                      type_option=detail.particle.is_optional,
                                      type_simple=type_simple,
-                                     type_array=detail.particle.max_occurs > 1,
+                                     type_array=detail.particle.is_array,
                                      type_array_length=f'{element_typename}->{detail.particle.name}.arrayLen',
                                      type_array_define=detail.particle.prefixed_define_for_array,
                                      next_grammar_id=next_grammar_id,

--- a/src/cbexigen/elementGrammar.py
+++ b/src/cbexigen/elementGrammar.py
@@ -38,7 +38,7 @@ class ElementGrammarDetail:
         if self.particle is None:
             return False
 
-        return self.particle.min_occurs == 0 and self.particle.max_occurs > 1
+        return self.particle.min_occurs == 0 and self.particle.is_array
 
     @property
     def is_mandatory(self):


### PR DESCRIPTION
## Describe your changes

I have updated all occurrences where particle.max_occurs > 1 was used directly to instead use the is_array property. This ensures consistency across the codebase and improves maintainability by centralizing the logic for determining whether a data type is an array. This change also facilitates compatibility with OpenV2G (I was trying to update the parser in order to make the autogenerated code compatible with OpenV2G), which has a different interpretation of unbounded data types with a max occurrence of 1. By using is_array consistently, any future modifications to array detection criteria can be easily applied throughout the project.

## Issue ticket number and link

[Issue number 107](https://github.com/EVerest/cbexigen/issues/107)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements
