### PR TITLE
Use memset for initializing EXI documents and fragments

### DIFF
--- a/src/cbexigen/datatype_classes.py
+++ b/src/cbexigen/datatype_classes.py
@@ -720,6 +720,7 @@ class DatatypeCode:
             self.config['root_struct_name']
         struct_type = self.parameters['prefix'] + self.config['root_struct_name']
         parameter_name = self.config['root_parameter_name']
+        use_memset = self.config['use_memset_root_content']
 
         if len(self.analyzer_data.root_elements) > 1:
             for element in self.analyzer_data.root_elements:
@@ -738,6 +739,7 @@ class DatatypeCode:
         temp = self.generator.get_template("BaseInitWithUsed.jinja")
 
         return temp.render(function_name=function_name,
+                           use_memset=use_memset,
                            struct_type=struct_type,
                            parameter_name=parameter_name,
                            element_comment=comment,
@@ -748,6 +750,7 @@ class DatatypeCode:
         struct_type = f'{self.__schema_prefix}{self.config["fragment_struct_name"]}'
         parameter_name = self.config['fragment_parameter_name']
         function_name = f'{self.config["init_function_prefix"]}{struct_type}'
+        use_memset = self.config['use_memset_child_elements']
 
         ele = []
         arr = []
@@ -768,6 +771,7 @@ class DatatypeCode:
         # generate init function with arrayLen = 0u and isUsed = 0u
         temp = self.generator.get_template("BaseInitWithArrayLenAndUsed.jinja")
         result = temp.render(function_name=function_name,
+                             use_memset=use_memset,
                              struct_type=struct_type,
                              parameter_name=parameter_name,
                              element_comment=comment,
@@ -785,6 +789,7 @@ class DatatypeCode:
         struct_type = f'{self.__schema_prefix}{self.config["xmldsig_fragment_struct_name"]}'
         parameter_name = self.config['xmldsig_fragment_parameter_name']
         function_name = f'{self.config["init_function_prefix"]}{struct_type}'
+        use_memset = self.config['use_memset_child_elements']
 
         ele = []
         arr = []
@@ -805,6 +810,7 @@ class DatatypeCode:
         # generate init function with arrayLen = 0u and isUsed = 0u
         temp = self.generator.get_template("BaseInitWithArrayLenAndUsed.jinja")
         result = temp.render(function_name=function_name,
+                             use_memset=use_memset,
                              struct_type=struct_type,
                              parameter_name=parameter_name,
                              element_comment=comment,
@@ -828,6 +834,7 @@ class DatatypeCode:
                 function_name = self.config['init_function_prefix'] + element.prefixed_type
                 struct_type = element.prefixed_type
                 parameter_name = element.type_short
+                use_memset = self.config['use_memset_child_elements']
 
                 if element.type_short == 'AnonType':
                     function_name = self.config['init_function_prefix'] + element.prefixed_name
@@ -856,6 +863,7 @@ class DatatypeCode:
                 # generate init function with arrayLen = 0u and isUsed = 0u
                 temp = self.generator.get_template("BaseInitWithArrayLenAndUsed.jinja")
                 result += temp.render(function_name=function_name,
+                                      use_memset=use_memset,
                                       struct_type=struct_type,
                                       parameter_name=parameter_name,
                                       element_comment=comment,

--- a/src/cbexigen/tools_config.py
+++ b/src/cbexigen/tools_config.py
@@ -48,6 +48,9 @@ CONFIG_PARAMS: Dict[str, Union[str, int]] = {
     # general c-code style
     'c_code_indent_chars': 4,
     'c_replace_chars': [' ', '-'],
+    # usage of memset
+    'use_memset_root_content': False,
+    'use_memset_child_elements': False,
 }
 
 __CONFIG_MODULE = None
@@ -185,6 +188,14 @@ def process_config_parameters():
     # c_replace_chars (replace with underscore)
     if hasattr(config_module, 'c_replace_chars'):
         CONFIG_PARAMS['c_replace_chars'] = config_module.c_replace_chars
+
+    ''' usage of memset '''
+    # initialization of EXI child elements
+    if hasattr(config_module, 'use_memset_root_content'):
+        CONFIG_PARAMS['use_memset_root_content'] = config_module.use_memset_root_content
+    # initialization of EXI child elements
+    if hasattr(config_module, 'use_memset_child_elements'):
+        CONFIG_PARAMS['use_memset_child_elements'] = config_module.use_memset_child_elements
 
 
 ISO2_SCHEMAS_URL = "https://standards.iso.org/iso/15118/-2/ed-2/en/"

--- a/src/config.py
+++ b/src/config.py
@@ -126,6 +126,12 @@ c_code_indent_chars = 4
 # these characters will be replaced by an underscore in generated code
 c_replace_chars = [' ', '-', '/']
 
+# Usage of memset for initialization of EXI Documents and Fragments
+use_memset_root_content = True
+
+# Usage of memset for initialization of EXI child elements
+use_memset_child_elements = True
+
 # files to be generated
 c_files_to_generate = {
     'exi_error_codes': {
@@ -287,7 +293,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'appHand_Datatypes.c',
             'identifier': 'APP_HANDSHAKE_DATATYPES_C',
-            'include_std_lib': [],
+            "include_std_lib": ["string.h"],
             'include_other': ['appHand_Datatypes.h']
         }
     },
@@ -344,7 +350,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'din_msgDefDatatypes.c',
             'identifier': 'DIN_MSG_DEF_DATATYPES_C',
-            'include_std_lib': [],
+            "include_std_lib": ["string.h"],
             'include_other': ['din_msgDefDatatypes.h']
         }
     },
@@ -400,7 +406,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'iso2_msgDefDatatypes.c',
             'identifier': 'ISO2_MSG_DEF_DATATYPES_C',
-            'include_std_lib': [],
+            "include_std_lib": ["string.h"],
             'include_other': ['iso2_msgDefDatatypes.h']
         }
     },
@@ -456,7 +462,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'iso20_CommonMessages_Datatypes.c',
             'identifier': 'ISO20_COMMON_MESSAGES_DATATYPES_C',
-            'include_std_lib': [],
+            "include_std_lib": ["string.h"],
             'include_other': ['iso20_CommonMessages_Datatypes.h']
         }
     },
@@ -513,7 +519,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'iso20_AC_Datatypes.c',
             'identifier': 'ISO20_AC_DATATYPES_C',
-            'include_std_lib': [],
+            "include_std_lib": ["string.h"],
             'include_other': ['iso20_AC_Datatypes.h']
         }
     },
@@ -569,7 +575,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'iso20_DC_Datatypes.c',
             'identifier': 'ISO20_DC_DATATYPES_C',
-            'include_std_lib': [],
+            "include_std_lib": ["string.h"],
             'include_other': ['iso20_DC_Datatypes.h']
         }
     },
@@ -626,7 +632,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'iso20_WPT_Datatypes.c',
             'identifier': 'ISO20_WPT_DATATYPES_C',
-            'include_std_lib': [],
+            "include_std_lib": ["string.h"],
             'include_other': ['iso20_WPT_Datatypes.h']
         }
     },
@@ -683,7 +689,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'iso20_ACDP_Datatypes.c',
             'identifier': 'ISO20_ACDP_DATATYPES_C',
-            'include_std_lib': [],
+            "include_std_lib": ["string.h"],
             'include_other': ['iso20_ACDP_Datatypes.h']
         }
     },

--- a/src/config.py
+++ b/src/config.py
@@ -293,7 +293,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'appHand_Datatypes.c',
             'identifier': 'APP_HANDSHAKE_DATATYPES_C',
-            "include_std_lib": ["string.h"],
+            'include_std_lib': ['string.h'],
             'include_other': ['appHand_Datatypes.h']
         }
     },
@@ -350,7 +350,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'din_msgDefDatatypes.c',
             'identifier': 'DIN_MSG_DEF_DATATYPES_C',
-            "include_std_lib": ["string.h"],
+            'include_std_lib': ['string.h'],
             'include_other': ['din_msgDefDatatypes.h']
         }
     },
@@ -406,7 +406,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'iso2_msgDefDatatypes.c',
             'identifier': 'ISO2_MSG_DEF_DATATYPES_C',
-            "include_std_lib": ["string.h"],
+            'include_std_lib': ['string.h'],
             'include_other': ['iso2_msgDefDatatypes.h']
         }
     },
@@ -462,7 +462,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'iso20_CommonMessages_Datatypes.c',
             'identifier': 'ISO20_COMMON_MESSAGES_DATATYPES_C',
-            "include_std_lib": ["string.h"],
+            'include_std_lib': ['string.h'],
             'include_other': ['iso20_CommonMessages_Datatypes.h']
         }
     },
@@ -519,7 +519,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'iso20_AC_Datatypes.c',
             'identifier': 'ISO20_AC_DATATYPES_C',
-            "include_std_lib": ["string.h"],
+            'include_std_lib': ['string.h'],
             'include_other': ['iso20_AC_Datatypes.h']
         }
     },
@@ -575,7 +575,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'iso20_DC_Datatypes.c',
             'identifier': 'ISO20_DC_DATATYPES_C',
-            "include_std_lib": ["string.h"],
+            'include_std_lib': ['string.h'],
             'include_other': ['iso20_DC_Datatypes.h']
         }
     },
@@ -632,7 +632,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'iso20_WPT_Datatypes.c',
             'identifier': 'ISO20_WPT_DATATYPES_C',
-            "include_std_lib": ["string.h"],
+            'include_std_lib': ['string.h'],
             'include_other': ['iso20_WPT_Datatypes.h']
         }
     },
@@ -689,7 +689,7 @@ c_files_to_generate = {
         'c': {
             'filename': 'iso20_ACDP_Datatypes.c',
             'identifier': 'ISO20_ACDP_DATATYPES_C',
-            "include_std_lib": ["string.h"],
+            'include_std_lib': ['string.h'],
             'include_other': ['iso20_ACDP_Datatypes.h']
         }
     },

--- a/src/input/code_templates/c/BaseInitWithArrayLenAndUsed.jinja
+++ b/src/input/code_templates/c/BaseInitWithArrayLenAndUsed.jinja
@@ -1,5 +1,8 @@
 {{ element_comment }}
 void {{ function_name }}(struct {{ struct_type }}* {{ parameter_name }}) {
+{%- if use_memset %}
+    memset({{ parameter_name }}, 0, sizeof(struct {{ struct_type }}));
+{%- else %}
     {%- if not arrays and not elements %}
     (void) {{ parameter_name }};
     {%- endif %}
@@ -9,4 +12,5 @@ void {{ function_name }}(struct {{ struct_type }}* {{ parameter_name }}) {
     {%- for name in elements %}
     {{ parameter_name }}->{{ name }}_isUsed = 0u;
     {%- endfor %}
+{%- endif %}
 }

--- a/src/input/code_templates/c/BaseInitWithUsed.jinja
+++ b/src/input/code_templates/c/BaseInitWithUsed.jinja
@@ -1,9 +1,13 @@
 {{ element_comment }}
 void {{ function_name }}(struct {{ struct_type }}* {{ parameter_name }}) {
+{%- if use_memset %}
+    memset({{ parameter_name }}, 0, sizeof(struct {{ struct_type }}));
+{%- else %}
     {%- if not elements %}
     (void) {{ parameter_name }};
     {%- endif %}
     {%- for name in elements %}
     {{ parameter_name }}->{{ name }}_isUsed = 0u;
     {%- endfor %}
+{%- endif %}
 }


### PR DESCRIPTION
## Describe your changes

This changes replace manual field-by-field initialization of EXI structs with memset, I hope it could help!

The implemented changes are:

-  Optional usage of memset when EXI documents and fragments are initialized
-  Optional usage of memset when any EXI element is initialized
-  Both parameters are set to True by default in config.py module

I tested the code against cbv2g copy-pasting the code and the tests passed:

<img width="923" height="434" alt="image" src="https://github.com/user-attachments/assets/a6e8769d-231a-4b39-a8ce-caa5204446d5" />

## Issue ticket number and link

This pull requests closes #117

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

