### PR TITLE
Fix array out of bounds for large arrays (#124)

### DIFF
--- a/src/cbexigen/base_coder_classes.py
+++ b/src/cbexigen/base_coder_classes.py
@@ -626,7 +626,7 @@ class ExiBaseCoderCode:
                     add_extra = (part.max_occurs >= 1 and part.max_occurs_was_changed)
                     skip_to_end = False  # for LOOP, do not create grammar for subsequent repetitions
                     for m in range(1, _max + 1):
-                        if skip_to_end:
+                        if skip_to_end and m < _max:
                             continue
                         if m < _max:
                             # flag=Grammar.LOOP indicates that the _next_ grammar will be the same as this one


### PR DESCRIPTION
## Summary
- Restores the `m < _max` guard in the array grammar loop that was accidentally removed in commit 871fcb3
- Without this guard, the final array grammar (is_in_array_last=True) is never generated when the LOOP optimization activates
- This causes `EXI_ERROR__ARRAY_OUT_OF_BOUNDS` when decoding arrays at their configured maximum size (e.g., ChargeParameterDiscoveryRes with 16 PMaxScheduleEntry elements)

## Test plan
- [ ] Generate codec with PMaxScheduleEntryType set to 16 in array optimizations
- [ ] Decode a ChargeParameterDiscoveryRes with 16 PMaxScheduleEntry elements
- [ ] Verify no EXI_ERROR__ARRAY_OUT_OF_BOUNDS error

Fixes #124