### PR TITLE
Fix out-of-bounds access in EXI bitstream bounds check

### DIFF
--- a/src/input/code_templates/c/static_code/exi_bitstream.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_bitstream.c.jinja
@@ -25,10 +25,11 @@ static int exi_bitstream_has_overflow(exi_bitstream_t* stream)
             }
 {%- endif %}
         }
-        else
-        {
-            return EXI_ERROR__BITSTREAM_OVERFLOW;
-        }
+    }
+
+    if (stream->byte_pos >= stream->data_size)
+    {
+        return EXI_ERROR__BITSTREAM_OVERFLOW;
     }
 
     return EXI_ERROR__NO_ERROR;

--- a/src/input/code_templates/c/static_code/exi_v2gtp.c.jinja
+++ b/src/input/code_templates/c/static_code/exi_v2gtp.c.jinja
@@ -48,14 +48,15 @@ int V2GTP20_ReadHeader(const uint8_t* stream_data, uint32_t* stream_payload_leng
     }
 
     /* check payload id */
-    payload_id = (stream_data[2] << 8) | stream_data[3];
+    payload_id = ((uint16_t)stream_data[2] << 8) | stream_data[3];
     if (payload_id != v2gtp20_payload_id)
     {
         return V2GTP_ERROR__PAYLOAD_ID_DOES_NOT_MATCH;
     }
 
     /* determine payload length */
-    *stream_payload_length = (stream_data[4] << 24) | (stream_data[5] << 16) | (stream_data[6] << 8) | stream_data[7];
+    *stream_payload_length = ((uint32_t)stream_data[4] << 24) | ((uint32_t)stream_data[5] << 16) |
+                             ((uint32_t)stream_data[6] << 8) | stream_data[7];
 
     return V2GTP_ERROR__NO_ERROR;
 }


### PR DESCRIPTION
Fix out-of-bounds access in EXI bitstream bounds check and undefined behavior in V2GTP header parsing

Fix 1:
exi_bitstream_has_overflow only advanced and validated byte_pos when bit_count reached a full byte (EXI_BITSTREAM_MAX_BIT_COUNT). It never checked that the byte about to be accessed was within the stream before exi_bitstream_read_bit and exi_bitstream_write_bit dereference data[byte_pos]. This allowed two out-of-bounds accesses:

- Empty input (data_size == 0): the first bit access dereferences data[0] on a zero-length buffer. Every message is decoded by first reading the 8-bit EXI header, so all decoders are reachable with a zero-byte input.
- End-of-buffer off-by-one: when bit_count rolls over at the last valid byte, byte_pos is advanced to data_size (one past the end) and the next access touches data[data_size].

Fix 2:
When left-shifting uint8_t bytes from stream_data, each operand is implicitly promoted to signed int. Shifting a value into the sign bit (e.g. stream_data[4] << 24) is undefined behavior in C, which can lead to incorrect payload length and payload id values depending on the compiler.

## Describe your changes
Add a bounds check after the byte-advance block that rejects when byte_pos >= data_size. It is placed after the advance so it validates the position actually about to be dereferenced, and it runs even when bit_count is 0, so empty input and a bad init offset are caught as well. The now-redundant else-return is removed, since the new check covers it; the increment stays guarded so byte_pos is not pushed past the end on the overflow path.

Cast the operands to uint16_t / uint32_t before shifting so the operations are performed on unsigned types of the intended width.

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

